### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-01-23
+
 ### Added
 
 - Initial release of graftpunk as a standalone package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "0.1.0"
+version = "1.0.0"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["browser", "session", "automation", "api", "scraping", "selenium", "requests"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -43,7 +43,7 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 __all__ = [
     # Version


### PR DESCRIPTION
## Summary

Release graftpunk v1.0.0 🎉

## Changes

- Bump version to 1.0.0 in pyproject.toml and __init__.py
- Update Development Status classifier to Production/Stable
- Update CHANGELOG with release date (2026-01-23)

## Post-merge

After merging:
1. Create git tag: `git tag v1.0.0`
2. Push tag: `git push origin v1.0.0`
3. Build: `just build`
4. Publish: `just publish`