### PR TITLE
feat: include nodriver in core dependencies (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-01-28
+
+### Changed
+
+- **NoDriver now included by default**: `pip install graftpunk` includes both Selenium and NoDriver backends
+- The `[nodriver]` extra is kept for backwards compatibility but is now a no-op
+
 ## [1.2.0] - 2026-01-27
 
 ### Added
@@ -22,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Eliminates WebDriver binary detection vector
   - Async-to-sync bridging for consistent API
   - Better anti-detection for enterprise-protected sites
-  - Install with `pip install graftpunk[nodriver]` or `pip install graftpunk[standard]`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ pip install graftpunk
 ```bash
 pip install graftpunk[supabase]   # Supabase backend
 pip install graftpunk[s3]         # AWS S3 backend
-pip install graftpunk[nodriver]   # NoDriver backend (better anti-detection)
-pip install graftpunk[standard]   # Recommended: NoDriver + stealth
 pip install graftpunk[all]        # Everything
 ```
 
@@ -255,12 +253,12 @@ Options:
 
 ## Browser Backends
 
-graftpunk supports multiple browser automation backends:
+graftpunk supports multiple browser automation backends (both included by default):
 
-| Backend | Install | Best For |
-|---------|---------|----------|
-| `selenium` | Default | Simple sites, backward compatibility |
-| `nodriver` | `pip install graftpunk[nodriver]` | Enterprise sites, better anti-detection |
+| Backend | Best For |
+|---------|----------|
+| `selenium` | Simple sites, backward compatibility |
+| `nodriver` | Enterprise sites, better anti-detection |
 
 ```python
 from graftpunk import BrowserSession, get_backend, list_backends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.2.0"
+version = "1.2.1"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"
@@ -43,6 +43,7 @@ dependencies = [
     "httpie>=3.0.0",
     "pyotp>=2.9.0",
     "pyyaml>=6.0",
+    "nodriver>=0.48",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +57,7 @@ jmespath = [
     "jmespath>=1.0.0",
 ]
 nodriver = [
-    "nodriver>=0.48",
+    # nodriver is now a core dependency; this extra is kept for backwards compatibility
 ]
 dev = [
     "pytest>=8.0.0",

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -44,7 +44,7 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -477,12 +477,13 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "dill" },
     { name = "httpie" },
+    { name = "nodriver" },
     { name = "pydantic-settings" },
     { name = "pyotp" },
     { name = "python-slugify" },
@@ -502,7 +503,6 @@ all = [
     { name = "boto3" },
     { name = "jmespath" },
     { name = "mypy" },
-    { name = "nodriver" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -518,9 +518,6 @@ dev = [
 ]
 jmespath = [
     { name = "jmespath" },
-]
-nodriver = [
-    { name = "nodriver" },
 ]
 s3 = [
     { name = "boto3" },
@@ -538,7 +535,7 @@ requires-dist = [
     { name = "httpie", specifier = ">=3.0.0" },
     { name = "jmespath", marker = "extra == 'jmespath'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
-    { name = "nodriver", marker = "extra == 'nodriver'", specifier = ">=0.48" },
+    { name = "nodriver", specifier = ">=0.48" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary

NoDriver is now installed by default with `pip install graftpunk`. No need for `[nodriver]` or `[standard]` extras.

## Changes

- Added `nodriver>=0.48` to core dependencies in pyproject.toml
- Kept `[nodriver]` extra as no-op for backwards compatibility  
- Removed `[standard]` references from README (never existed in pyproject.toml)
- Updated Browser Backends documentation
- Version bump to 1.2.1

## Why

If the whole point of graftpunk is stealth browser automation, the best anti-detection backend should be included by default.