### PR TITLE
fix: suppress nodriver cleanup noise during browser stop

### DIFF
--- a/src/graftpunk/session.py
+++ b/src/graftpunk/session.py
@@ -419,7 +419,7 @@ class BrowserSession(requestium.Session):
         exc_tb: Any,
     ) -> None:
         await self._stop_observe_async(exc_type)
-        self.quit()
+        await self._quit_async()
 
     def quit(self) -> None:
         """Close the browser and clean up resources.
@@ -434,6 +434,37 @@ class BrowserSession(requestium.Session):
             LOG.info("stopping_nodriver_session")
             try:
                 backend_instance.stop()
+            except Exception as exc:
+                LOG.error(
+                    "error_stopping_nodriver_session", error=str(exc), exc_type=type(exc).__name__
+                )
+            self._backend_instance = None
+        elif hasattr(self, "_webdriver") and self._webdriver is not None:
+            LOG.info("stopping_selenium_session")
+            try:
+                self._webdriver.quit()
+            except Exception as exc:
+                LOG.error(
+                    "error_stopping_selenium_session", error=str(exc), exc_type=type(exc).__name__
+                )
+            self._webdriver = None
+
+    async def _quit_async(self) -> None:
+        """Async version of quit for use in ``__aexit__``.
+
+        Uses the backend's async stop path to avoid nested ``asyncio.run()``
+        errors when shutting down from within an existing event loop.
+        """
+        backend_instance = getattr(self, "_backend_instance", None)
+        backend_type = getattr(self, "_backend_type", "selenium")
+
+        if backend_type == "nodriver" and backend_instance is not None:
+            LOG.info("stopping_nodriver_session")
+            try:
+                if hasattr(backend_instance, "stop_async"):
+                    await backend_instance.stop_async()
+                else:
+                    backend_instance.stop()
             except Exception as exc:
                 LOG.error(
                     "error_stopping_nodriver_session", error=str(exc), exc_type=type(exc).__name__

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1116,7 +1116,7 @@ class TestBrowserSessionContextManager:
 
     @pytest.mark.asyncio
     async def test_async_context_manager_starts_and_quits(self):
-        """'async with BrowserSession(...)' calls start_async and quit."""
+        """'async with BrowserSession(...)' calls start_async and _quit_async."""
         from graftpunk.session import BrowserSession
 
         with patch.object(BrowserSession, "__init__", return_value=None):
@@ -1128,7 +1128,7 @@ class TestBrowserSessionContextManager:
             session._observe_storage = None
             with (
                 patch.object(session, "start_async", new_callable=AsyncMock) as mock_start,
-                patch.object(session, "quit") as mock_quit,
+                patch.object(session, "_quit_async", new_callable=AsyncMock) as mock_quit,
             ):
                 async with session as s:
                     assert s is session
@@ -1137,7 +1137,7 @@ class TestBrowserSessionContextManager:
 
     @pytest.mark.asyncio
     async def test_async_context_manager_quits_on_exception(self):
-        """'async with BrowserSession(...)' calls quit() even when exception raised."""
+        """'async with BrowserSession(...)' calls _quit_async() even when exception raised."""
         from graftpunk.session import BrowserSession
 
         with patch.object(BrowserSession, "__init__", return_value=None):
@@ -1149,7 +1149,7 @@ class TestBrowserSessionContextManager:
             session._observe_storage = None
             with (
                 patch.object(session, "start_async", new_callable=AsyncMock),
-                patch.object(session, "quit") as mock_quit,
+                patch.object(session, "_quit_async", new_callable=AsyncMock) as mock_quit,
             ):
                 with pytest.raises(RuntimeError, match="test"):
                     async with session:


### PR DESCRIPTION
## Summary
- Add `stop_async()` to NoDriverBackend for async contexts (fixes nested `asyncio.run()` error in `__aexit__`)
- Add `_quit_async()` to BrowserSession, used by `__aexit__`
- Deregister browser from nodriver global registry after stop to prevent atexit cleanup noise
- Suppress asyncio "Loop ... is closed" warning during login
- Suppress nodriver "successfully removed temp profile" stdout print

## Test plan
- [x] All 1308 tests pass
- [x] Ruff lint clean
- [x] Manual test: `gp bek login` produces clean output (no warnings or Loop messages)