### PR TITLE
fix: load_session_for_api overwrites browser UA with python-requests default (#52)

### DIFF
--- a/src/graftpunk/cache.py
+++ b/src/graftpunk/cache.py
@@ -383,9 +383,17 @@ def load_session_for_api(name: str) -> requests.Session:
             cookie_count=len(browser_session.cookies),
         )
 
-    # Copy headers from browser session
+    # Copy headers from browser session, but skip requests-library defaults
+    # that would clobber browser identity headers extracted from profiles.
+    # The pickled BrowserSession (a requests.Session) carries default headers
+    # like User-Agent: python-requests/2.x — copying them overwrites the
+    # Chrome UA that _apply_browser_identity() set during GraftpunkSession init.
     if hasattr(browser_session, "headers"):
-        api_session.headers.update(browser_session.headers)
+        _requests_defaults = requests.utils.default_headers()
+        for key, value in browser_session.headers.items():
+            if key in _requests_defaults and _requests_defaults[key] == value:
+                continue
+            api_session.headers[key] = value
         LOG.debug("copied_headers_from_session")
 
     # Copy cached tokens from browser session


### PR DESCRIPTION
## Summary

Fixes #52. `load_session_for_api()` in `cache.py` overwrites the Chrome User-Agent that `GraftpunkSession.__init__()` correctly extracted from header profiles, replacing it with the `requests` library default (`python-requests/2.x`). This causes Akamai-protected sites to silently drop requests.

## Root cause

```python
# __init__ runs _apply_browser_identity() → sets Chrome UA on self.headers  ✓
api_session = GraftpunkSession(header_profiles=header_profiles)

# This OVERWRITES the Chrome UA with browser_session.headers,
# which contains: User-Agent: python-requests/2.32.5  ✗
api_session.headers.update(browser_session.headers)
```

The pickled `BrowserSession` (a `requests.Session`) carries `requests.utils.default_headers()` in its `.headers` dict — including `User-Agent: python-requests/2.x`. The blanket `.update()` clobbers the Chrome UA that `_apply_browser_identity()` set moments earlier.

Other identity headers (`sec-ch-ua`, `sec-ch-ua-platform`, `sec-ch-ua-mobile`) were unaffected because they're not in the `requests` defaults and therefore don't get overwritten.

## Fix

Filter out headers whose values match `requests.utils.default_headers()` when copying from `browser_session.headers`:

```python
_requests_defaults = requests.utils.default_headers()
for key, value in browser_session.headers.items():
    if key in _requests_defaults and _requests_defaults[key] == value:
        continue
    api_session.headers[key] = value
```

This preserves:
- Browser identity headers from `_apply_browser_identity()` (Chrome UA, sec-ch-ua, etc.)
- Any headers explicitly set on the `BrowserSession` (custom User-Agent, X-Custom-Header, etc.)

And skips:
- `requests` library defaults that would clobber profile-extracted identity

## Why existing tests didn't catch this

The `load_session_for_api` tests used `mock_session.headers = {"User-Agent": "test"}` — a trivial mock that doesn't reproduce the real scenario where `browser_session.headers` contains `requests.utils.default_headers()`. No test verified the final `User-Agent` on the returned session was the Chrome UA from profiles.

## Test plan

- [x] `test_load_session_for_api_browser_identity_not_clobbered` — mock with real `requests.utils.default_headers()`, verify Chrome UA from profiles survives
- [x] `test_load_session_for_api_custom_browser_session_headers_preserved` — non-default headers (X-Custom-Header, explicitly-set UA) are still copied through
- [x] Full suite: 1498 tests passing
- [x] Ruff lint + format clean
- [x] ty type checker clean