### PR TITLE
fix: write format_output to stdout instead of stderr

### DIFF
--- a/src/graftpunk/cli/plugin_commands.py
+++ b/src/graftpunk/cli/plugin_commands.py
@@ -42,7 +42,7 @@ from graftpunk.plugins.python_loader import discover_python_plugins
 from graftpunk.plugins.yaml_plugin import create_yaml_plugins
 
 LOG = get_logger(__name__)
-_format_console = Console(stderr=True)
+_format_console = Console()
 
 _registered_plugins_for_teardown: list[CLIPluginProtocol] = []
 


### PR DESCRIPTION
## Summary

- Change `_format_console` from `Console(stderr=True)` to `Console()` so command data output goes to stdout

This is a one-line fix. The format console was directing all `format_output()` calls to stderr, breaking standard Unix piping and redirection for every formatter and every plugin.

Closes #59

## Test plan

- [x] Full test suite passes (1458 passed)
- [x] ruff check clean
- [ ] Manual: `gp <plugin> <command> -f csv > file.csv` writes to file instead of empty
- [ ] Manual: `gp <plugin> <command> -f json | jq '.'` receives data on stdin