### PR TITLE
feat: update example plugins for steps-based LoginConfig API (#71)

### DIFF
--- a/examples/plugins/hackernews.py
+++ b/examples/plugins/hackernews.py
@@ -9,7 +9,7 @@ Usage:
     3. Use: gp hn front
 """
 
-from graftpunk.plugins import CommandContext, LoginConfig, SitePlugin, command
+from graftpunk.plugins import CommandContext, LoginConfig, LoginStep, SitePlugin, command
 
 
 class HackerNewsPlugin(SitePlugin):
@@ -24,9 +24,16 @@ class HackerNewsPlugin(SitePlugin):
 
     login_config = LoginConfig(
         url="/login",
-        fields={"username": "input[name='acct']", "password": "input[name='pw']"},
-        submit="input[value='login']",
         failure="Bad login.",
+        steps=[
+            LoginStep(
+                fields={
+                    "username": "input[name='acct']",
+                    "password": "input[name='pw']",
+                },
+                submit="input[value='login']",
+            ),
+        ],
     )
 
     # token_config: No CSRF tokens needed for Hacker News.

--- a/examples/plugins/quotes.py
+++ b/examples/plugins/quotes.py
@@ -9,7 +9,7 @@ Usage:
     3. Use: gp quotes list
 """
 
-from graftpunk.plugins import CommandContext, LoginConfig, SitePlugin, command
+from graftpunk.plugins import CommandContext, LoginConfig, LoginStep, SitePlugin, command
 
 
 class QuotesPlugin(SitePlugin):
@@ -24,9 +24,13 @@ class QuotesPlugin(SitePlugin):
 
     login_config = LoginConfig(
         url="/login",
-        fields={"username": "#username", "password": "#password"},
-        submit="input[type='submit']",
         success="a[href='/logout']",
+        steps=[
+            LoginStep(
+                fields={"username": "#username", "password": "#password"},
+                submit="input[type='submit']",
+            ),
+        ],
     )
 
     # token_config: No CSRF tokens needed for this test site.

--- a/examples/templates/yaml_template.yaml
+++ b/examples/templates/yaml_template.yaml
@@ -18,12 +18,21 @@ base_url: "https://example.com"      # Optional: prepended to command URLs
 # Uncomment to enable declarative login:
 # login:
 #   url: /login
-#   fields:
-#     username: "input#email"
-#     password: "input#password"
-#   submit: "button[type=submit]"
 #   failure: "Invalid credentials"
 #   success: ".dashboard"
+#   steps:
+#     - fields:
+#         username: "input#email"
+#         password: "input#password"
+#       submit: "button[type=submit]"
+#     # Multi-step login example (e.g., identifier-first flows):
+#     # - fields:
+#     #     username: "input#email"
+#     #   submit: "button#next"
+#     #   wait_for: "input#password"  # nodriver only
+#     # - fields:
+#     #     password: "input#password"
+#     #   submit: "button#signin"
 
 # Optional: Token extraction for CSRF or dynamic headers
 # tokens:


### PR DESCRIPTION
## Summary

- Update example plugins (`hackernews.py`, `quotes.py`) to use the new `LoginStep`-based `LoginConfig` format
- Update YAML template (`yaml_template.yaml`) with steps-based login config and a commented multi-step example for identifier-first flows

## Context

Part of #71 — multi-step login support for identifier-first / split authentication flows (e.g., Azure AD B2C, Okta, Google).

This PR updates the example plugins and templates to reflect the new `LoginConfig.steps` API that replaces the flat `fields` + `submit` pattern.

## Test plan

- [ ] Verify example plugins match the current `LoginConfig` / `LoginStep` API
- [ ] Verify YAML template renders correctly with the new steps format