### PR TITLE
chore: release v1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.2.1"
+version = "1.3.0"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -45,7 +45,7 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 __all__ = [
     # Version


### PR DESCRIPTION
## Summary
- Bump version to 1.3.0 in `pyproject.toml` and `__init__.py`
- Update CHANGELOG.md with all changes since v1.2.1

## After merge
Run `just release` from main to tag, create GitHub release, and publish to PyPI.