### PR TITLE
chore: sync uv.lock with v1.3.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Summary
- Sync uv.lock version to match pyproject.toml v1.3.0 bump

Missed from #86. Blocks `just release`.