### PR TITLE
chore: CHANGELOG 1.5.0 release date + bump recipe CHANGELOG step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-02-11
 
 ### Fixed
 

--- a/justfile
+++ b/justfile
@@ -245,6 +245,15 @@ bump VERSION:
     # Update __init__.py
     sed -i '' "s/__version__ = \"${OLD}\"/__version__ = \"${NEW}\"/" src/graftpunk/__init__.py
 
+    # Update CHANGELOG: rename [Unreleased] to [X.Y.Z] with today's date
+    DATE=$(date +%Y-%m-%d)
+    if grep -q '## \[Unreleased\]' CHANGELOG.md; then
+        sed -i '' "s/## \[Unreleased\]/## [${NEW}] - ${DATE}/" CHANGELOG.md
+        echo "✅ CHANGELOG.md: [Unreleased] → [${NEW}] - ${DATE}"
+    else
+        echo "⚠️  No [Unreleased] section found in CHANGELOG.md — skipping"
+    fi
+
     # Update lockfile
     uv lock --quiet
     echo "✅ Updated pyproject.toml, __init__.py, uv.lock"
@@ -252,7 +261,7 @@ bump VERSION:
     # Create branch, commit, and PR
     BRANCH="chore/bump-v${NEW}"
     git checkout -b "$BRANCH"
-    git add pyproject.toml src/graftpunk/__init__.py uv.lock
+    git add pyproject.toml src/graftpunk/__init__.py uv.lock CHANGELOG.md
     git commit -m "chore: bump version to ${NEW}"
     git push -u origin "$BRANCH"
     gh pr create --title "chore: bump version to ${NEW}" --body "Bump version ${OLD} → ${NEW} (pyproject.toml, __init__.py, uv.lock)"


### PR DESCRIPTION
## Summary

- Rename `[Unreleased]` → `[1.5.0] - 2026-02-11` so `just release` passes the CHANGELOG check
- Add CHANGELOG step to `just bump` — automatically renames `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` and includes `CHANGELOG.md` in the commit

### Before

`just bump` updated `pyproject.toml`, `__init__.py`, `uv.lock` but left the CHANGELOG as `[Unreleased]`, requiring a manual rename before `just release`.

### After

`just bump 1.6.0` also renames `[Unreleased]` → `[1.6.0] - 2026-02-11` in `CHANGELOG.md`. If no `[Unreleased]` section exists, it warns and skips.