### PR TITLE
fix: apply column filter to single-dict views

### DIFF
--- a/src/graftpunk/plugins/formatters.py
+++ b/src/graftpunk/plugins/formatters.py
@@ -74,6 +74,8 @@ def _resolve_view_data(data: Any, view: ViewConfig) -> Any | None:
         return None
     if isinstance(view_data, list) and view_data and isinstance(view_data[0], dict):
         view_data = apply_column_filter(view_data, view.columns)
+    elif isinstance(view_data, dict) and view.columns:
+        view_data = apply_column_filter([view_data], view.columns)[0]
     return view_data
 
 


### PR DESCRIPTION
## Summary
- `_resolve_view_data` only applied `ColumnFilter` to `list[dict]` data
- Views without a `path` (rendering the top-level dict as key-value pairs) never had their exclude/include filter applied
- This caused excluded keys like `invoices` to render as massive JSON blobs in summary views

## Test plan
- [x] Existing formatter tests pass (92/92, 4 openpyxl-dependent skipped)
- [x] Verified with `gp bek invoice list` — Account Summary view now correctly excludes `invoices` key
- [x] Verified with `gp bek order list` — Page Info view correctly excludes `orders` key