### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-02-18
+
+### Fixed
+
+- **Intermittent nodriver browser startup failure** — `_start_async()` now retries `uc.start()` up to 3 times with back-off when Chrome's CDP port isn't ready within nodriver's ~2.75s timeout (common on macOS under load)
+- Sync `start()` now catches the bare `Exception` that nodriver raises on connection failure, wrapping it as `BrowserError` instead of letting it propagate unwrapped
+
 ## [1.7.0] - 2026-02-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.7.0"
+version = "1.7.1"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -47,7 +47,7 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
Bump version 1.7.0 → 1.7.1 (pyproject.toml, __init__.py, uv.lock)