### PR TITLE
fix: isolate storage config tests from .env file

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,8 +14,14 @@ _STORAGE_ENV_VARS = [
 
 
 @pytest.fixture()
-def _clean_storage_env(monkeypatch):
-    """Remove storage env vars so tests see default settings."""
+def _clean_storage_env(monkeypatch, tmp_path):
+    """Remove storage env vars so tests see default settings.
+
+    monkeypatch.delenv() only patches os.environ, but pydantic-settings
+    also reads .env files directly (``env_file=".env"``).  Changing to
+    a temp directory prevents it from finding the project's .env.
+    """
+    monkeypatch.chdir(tmp_path)
     for var in _STORAGE_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     reset_settings()


### PR DESCRIPTION
## Summary
- `_clean_storage_env` fixture used `monkeypatch.delenv()` to clear storage env vars, but pydantic-settings also reads `.env` files directly (`env_file=".env"`)
- When the project `.env` contains S3/R2 configuration, those values leaked into tests expecting clean defaults, causing 3 failures in `test_config.py`
- Fix: `monkeypatch.chdir(tmp_path)` so pydantic-settings can't find the `.env` file

## Test plan
- [x] All 11 `test_config.py` tests pass
- [x] Full suite passes (2087/2087)