### PR TITLE
fix: add retry logic and sandbox=False to nodriver startup in observe/tokens

### DIFF
--- a/src/graftpunk/cli/main.py
+++ b/src/graftpunk/cli/main.py
@@ -458,7 +458,34 @@ async def _setup_observe_session(
     # so Ctrl+C only reaches Python. We save data, then explicitly stop Chrome.
     old_sigint = signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        browser = await nodriver.start(headless=headless)
+        # Retry logic matching NoDriverBackend._start_async()
+        max_attempts = 3
+        last_exc: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                browser = await nodriver.start(
+                    headless=headless,
+                    sandbox=False,
+                    browser_args=["--test-type"],
+                )
+                break
+            except Exception as exc:
+                last_exc = exc
+                if "Failed to connect to browser" not in str(exc):
+                    raise
+                if attempt < max_attempts:
+                    LOG.warning(
+                        "observe_browser_connect_retry",
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                    )
+                    await asyncio.sleep(1.0 * attempt)
+        else:
+            raise RuntimeError(
+                f"Failed to connect to browser after {max_attempts} attempts. "
+                "Chrome may be slow to start — try again, or check for stale "
+                "Chrome processes."
+            ) from last_exc
     finally:
         signal.signal(signal.SIGINT, old_sigint)
     try:

--- a/src/graftpunk/tokens.py
+++ b/src/graftpunk/tokens.py
@@ -34,10 +34,36 @@ async def nodriver_start(*, headless: bool = True) -> Any:
     """Start a nodriver browser instance.
 
     Thin wrapper to isolate the nodriver import for testability.
+    Retries on connection failure, matching NoDriverBackend._start_async().
     """
     import nodriver
 
-    return await nodriver.start(headless=headless)
+    max_attempts = 3
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await nodriver.start(
+                headless=headless,
+                sandbox=False,
+                browser_args=["--test-type"],
+            )
+        except Exception as exc:
+            last_exc = exc
+            if "Failed to connect to browser" not in str(exc):
+                raise
+            if attempt < max_attempts:
+                LOG.warning(
+                    "nodriver_start_retry",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                )
+                await asyncio.sleep(1.0 * attempt)
+
+    raise RuntimeError(
+        f"Failed to connect to browser after {max_attempts} attempts. "
+        "Chrome may be slow to start — try again, or check for stale "
+        "Chrome processes."
+    ) from last_exc
 
 
 def _deregister_nodriver_browser(browser: Any) -> None:


### PR DESCRIPTION
## Summary
- Adds retry-on-connection-failure logic to `nodriver_start()` in `tokens.py` and `_setup_observe_session()` in `cli/main.py`, matching the existing pattern in `NoDriverBackend._start_async()`
- Passes `sandbox=False` and `--test-type` browser args consistently across all nodriver launch sites
- Fixes intermittent "Failed to connect to browser" errors in observe mode and token extraction

## Test plan
- [x] Full test suite passes (2087 tests)
- [x] Ruff lint and format checks pass
- [ ] Manual test: `gp observe` on a slow-starting system to verify retry kicks in