### PR TITLE
chore: release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-03-04
+
+### Fixed
+
+- **Intermittent nodriver startup failure in observe mode and token extraction** — `nodriver_start()` in `tokens.py` and `_setup_observe_session()` in `cli/main.py` now retry on "Failed to connect to browser" with back-off, matching the existing pattern in `NoDriverBackend._start_async()`. Also passes `sandbox=False` and `--test-type` browser args consistently across all nodriver launch sites.
+- **`ty` type-check errors in encryption vault parsing** — added explicit `dict[str, str]` type narrowing for Supabase RPC `result.data` so `ty` can resolve the `.get()` overload
+
+### Changed
+
+- **Test suite runs 13x faster** (120s → 9s) via two improvements:
+  - Patched login engine timing constants (`_ELEMENT_WAIT_TIMEOUT`, `_POST_SUBMIT_DELAY`, `_ELEMENT_RETRY_INTERVAL`) in tests via a shared `_fast_login_timings` fixture — eliminates 30s real-clock deadline loops and 3s real sleeps
+  - Added `pytest-xdist` for parallel test execution (`-n auto` default in `addopts`)
+- `_select_with_retry()` now uses `None` sentinel defaults resolved at call time (instead of definition time) so `monkeypatch.setattr` on module constants takes effect in tests
+
 ## [1.8.0] - 2026-02-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.8.0"
+version = "1.8.1"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Summary
- Bump version to 1.8.1
- Add changelog entry for 1.8.1

### 1.8.1 changelog

**Fixed:**
- Intermittent nodriver startup failure in observe mode and token extraction (retry + sandbox=False)
- `ty` type-check errors in encryption vault parsing

**Changed:**
- Test suite runs 13x faster (120s → 9s) via timing constant patches and pytest-xdist
- `_select_with_retry()` uses call-time default resolution for monkeypatch compatibility

## Test plan
- [x] All 2087 tests pass