### PR TITLE
Fix Chrome 146 cookie transfer hang (nodriver sameParty compat)

### DIFF
--- a/src/graftpunk/backends/nodriver.py
+++ b/src/graftpunk/backends/nodriver.py
@@ -44,6 +44,35 @@ if TYPE_CHECKING:
 LOG = get_logger(__name__)
 
 
+def _patch_nodriver_cookie_compat() -> None:
+    """Patch nodriver's Cookie.from_json to handle missing ``sameParty`` field.
+
+    Chrome 146+ removed ``sameParty`` from CDP cookie responses, but nodriver's
+    auto-generated ``network.Cookie.from_json()`` does a hard ``json['sameParty']``
+    lookup that raises ``KeyError``.  This kills the CDP listener task and leaves
+    the ``Storage.getCookies`` Future unresolved, hanging the caller forever.
+
+    Applied once at import time so all cookie operations are safe.
+    """
+    try:
+        from nodriver.cdp.network import Cookie
+
+        _original_from_json = Cookie.from_json.__func__  # type: ignore[attr-defined]
+
+        @classmethod  # type: ignore[misc]
+        def _patched_from_json(cls, json):  # type: ignore[no-untyped-def]  # noqa: N805, ANN001
+            json.setdefault("sameParty", False)
+            return _original_from_json(cls, json)
+
+        Cookie.from_json = _patched_from_json  # type: ignore[assignment]
+        LOG.debug("nodriver_cookie_compat_patched")
+    except Exception:
+        LOG.debug("nodriver_cookie_compat_patch_skipped")
+
+
+_patch_nodriver_cookie_compat()
+
+
 @contextmanager
 def _suppress_nodriver_cleanup_noise():
     """Suppress noisy stdout from nodriver cleanup during browser stop.


### PR DESCRIPTION
## Summary
- Monkey-patch `nodriver.cdp.network.Cookie.from_json` at import time to default `sameParty` to `False` when missing
- Chrome 146 removed this field from CDP responses; nodriver's hard `json['sameParty']` lookup crashes the CDP listener, leaving `Storage.getCookies` hung forever

Fixes #125

## Test plan
- [x] 2087 tests pass
- [x] `gp -vv bek login` completes in ~10s with 14 cookies transferred and CSRF token extracted