### PR TITLE
fix: reap chrome subprocess in NoDriverBackend.stop() (closes #127)

### DIFF
--- a/src/graftpunk/backends/nodriver.py
+++ b/src/graftpunk/backends/nodriver.py
@@ -82,14 +82,14 @@ async def _reap_browser_process(proc: asyncio.subprocess.Process | None) -> None
         return
     try:
         await asyncio.wait_for(proc.wait(), _REAP_TERM_TIMEOUT_S)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         try:
             proc.kill()
         except ProcessLookupError:
             return
         try:
             await asyncio.wait_for(proc.wait(), _REAP_KILL_TIMEOUT_S)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             LOG.warning("chrome_failed_to_exit_after_sigkill", pid=proc.pid)
 
 

--- a/src/graftpunk/backends/nodriver.py
+++ b/src/graftpunk/backends/nodriver.py
@@ -45,6 +45,53 @@ LOG = get_logger(__name__)
 
 _nodriver_cookie_patched = False
 
+# Subprocess reap timeouts. nodriver's Browser.stop() sends SIGTERM (or kill
+# fallback) but never awaits proc.wait(), so the Chrome subprocess sits as a
+# zombie under the live python parent. _reap_browser_process below awaits
+# the subprocess to give the kernel a chance to collect its exit status.
+# Module-level constants (rather than function defaults) so tests can
+# monkeypatch tight timeouts.
+_REAP_TERM_TIMEOUT_S: float = 3.0
+_REAP_KILL_TIMEOUT_S: float = 1.0
+
+
+async def _reap_browser_process(proc: asyncio.subprocess.Process | None) -> None:
+    """Await Chrome subprocess exit so the kernel can reap it.
+
+    nodriver's Browser.stop() calls proc.terminate() (or proc.kill() as a
+    fallback) and then sets self._process = None without ever awaiting
+    proc.wait(). asyncio child processes must be wait()ed for the kernel to
+    collect their exit status; otherwise they accumulate as <defunct>
+    (zombie) entries under the parent.
+
+    Behavior:
+      1. await wait_for(proc.wait(), _REAP_TERM_TIMEOUT_S) — normal SIGTERM path.
+      2. On timeout: proc.kill() (SIGKILL), then await wait_for(proc.wait(),
+         _REAP_KILL_TIMEOUT_S). SIGKILL cannot be caught/ignored, so the
+         second wait should always return.
+      3. On second timeout (kernel-level wedge): log a warning and return.
+         The zombie persists until the python process exits.
+      4. ProcessLookupError from proc.kill() is swallowed — Chrome exited in
+         the race window between the first wait timeout and our kill call.
+
+    Args:
+        proc: The asyncio subprocess. None is a no-op (start() may have
+            failed before subprocess spawn, or the backend was never started).
+    """
+    if proc is None:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), _REAP_TERM_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), _REAP_KILL_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            LOG.warning("chrome_failed_to_exit_after_sigkill", pid=proc.pid)
+
 
 def _patch_nodriver_cookie_parsing() -> None:
     """Patch nodriver's Cookie.from_json to handle missing 'sameParty' field.
@@ -368,6 +415,11 @@ class NoDriverBackend:
             pass to asyncio.run().
         """
         if self._browser is not None:
+            # Capture the subprocess BEFORE browser.stop() runs, because
+            # nodriver's stop() resets self._process = None inside its
+            # cleanup loop. If we read it afterward, we get None and the
+            # reap silently no-ops.
+            proc = getattr(self._browser, "_process", None)
             try:
                 self._browser.stop()
             except (RuntimeError, OSError) as exc:
@@ -375,6 +427,15 @@ class NoDriverBackend:
             # Remove browser from nodriver's global registry so the atexit
             # handler doesn't re-stop it and print cleanup messages to stdout.
             self._deregister_browser()
+            # Reap the Chrome subprocess. nodriver's Browser.stop() sends
+            # SIGTERM but never awaits proc.wait(), leaving Chrome as a
+            # zombie under the live python parent.
+            #
+            # Edge case: if browser.stop() raised BEFORE sending SIGTERM,
+            # the helper will pay one _REAP_TERM_TIMEOUT_S (3s) wait before
+            # the SIGKILL escalation reaps the process. Acceptable — error
+            # paths are rare and a 3s delay is bounded.
+            await _reap_browser_process(proc)
 
     def stop(self) -> None:
         """Stop the browser and release resources.

--- a/src/graftpunk/backends/nodriver.py
+++ b/src/graftpunk/backends/nodriver.py
@@ -66,13 +66,15 @@ async def _reap_browser_process(proc: asyncio.subprocess.Process | None) -> None
 
     Behavior:
       1. await wait_for(proc.wait(), _REAP_TERM_TIMEOUT_S) — normal SIGTERM path.
-      2. On timeout: proc.kill() (SIGKILL), then await wait_for(proc.wait(),
-         _REAP_KILL_TIMEOUT_S). SIGKILL cannot be caught/ignored, so the
-         second wait should always return.
+      2. On timeout: log debug, then proc.kill() (SIGKILL), then await
+         wait_for(proc.wait(), _REAP_KILL_TIMEOUT_S). SIGKILL cannot be
+         caught/ignored, so the second wait should always return.
       3. On second timeout (kernel-level wedge): log a warning and return.
          The zombie persists until the python process exits.
       4. ProcessLookupError from proc.kill() is swallowed — Chrome exited in
          the race window between the first wait timeout and our kill call.
+      5. Other OSError from proc.kill() (e.g. EPERM under sandboxed runs):
+         log a distinct warning and return.
 
     Args:
         proc: The asyncio subprocess. None is a no-op (start() may have
@@ -83,14 +85,27 @@ async def _reap_browser_process(proc: asyncio.subprocess.Process | None) -> None
     try:
         await asyncio.wait_for(proc.wait(), _REAP_TERM_TIMEOUT_S)
     except TimeoutError:
+        LOG.debug("chrome_sigterm_timeout_escalating_to_sigkill", pid=proc.pid)
         try:
             proc.kill()
         except ProcessLookupError:
             return
+        except OSError as exc:
+            LOG.warning(
+                "chrome_kill_failed",
+                pid=proc.pid,
+                errno=exc.errno,
+                error=str(exc),
+            )
+            return
         try:
             await asyncio.wait_for(proc.wait(), _REAP_KILL_TIMEOUT_S)
         except TimeoutError:
-            LOG.warning("chrome_failed_to_exit_after_sigkill", pid=proc.pid)
+            LOG.warning(
+                "chrome_failed_to_exit_after_sigkill",
+                pid=proc.pid,
+                returncode=proc.returncode,
+            )
 
 
 def _patch_nodriver_cookie_parsing() -> None:
@@ -415,27 +430,37 @@ class NoDriverBackend:
             pass to asyncio.run().
         """
         if self._browser is not None:
-            # Capture the subprocess BEFORE browser.stop() runs, because
-            # nodriver's stop() resets self._process = None inside its
-            # cleanup loop. If we read it afterward, we get None and the
-            # reap silently no-ops.
+            # Capture the subprocess BEFORE browser.stop(), defensively.
+            # nodriver's stop() may null self._process on its all-failures
+            # path (and could in future versions on the happy path too).
+            # Reading after stop() risks getting None and silently no-op'ing
+            # the reap.
             proc = getattr(self._browser, "_process", None)
+            # try/finally guarantees the reap runs even if browser.stop() or
+            # _deregister_browser() raise an unexpected exception (anything
+            # outside the (RuntimeError, OSError) handled set). Reaping is
+            # most critical exactly on the error paths where Chrome is most
+            # likely to leak — don't let a stop() failure also leak the
+            # subprocess.
             try:
-                self._browser.stop()
-            except (RuntimeError, OSError) as exc:
-                self._handle_stop_error(exc)
-            # Remove browser from nodriver's global registry so the atexit
-            # handler doesn't re-stop it and print cleanup messages to stdout.
-            self._deregister_browser()
-            # Reap the Chrome subprocess. nodriver's Browser.stop() sends
-            # SIGTERM but never awaits proc.wait(), leaving Chrome as a
-            # zombie under the live python parent.
-            #
-            # Edge case: if browser.stop() raised BEFORE sending SIGTERM,
-            # the helper will pay one _REAP_TERM_TIMEOUT_S (3s) wait before
-            # the SIGKILL escalation reaps the process. Acceptable — error
-            # paths are rare and a 3s delay is bounded.
-            await _reap_browser_process(proc)
+                try:
+                    self._browser.stop()
+                except (RuntimeError, OSError) as exc:
+                    self._handle_stop_error(exc)
+                # Remove browser from nodriver's global registry so the atexit
+                # handler doesn't re-stop it and print cleanup messages to stdout.
+                self._deregister_browser()
+            finally:
+                # Reap the Chrome subprocess. nodriver's Browser.stop() sends
+                # SIGTERM but never awaits proc.wait(), leaving Chrome as a
+                # zombie under the live python parent.
+                #
+                # Edge case: if browser.stop() raised before sending SIGTERM,
+                # the helper will pay one _REAP_TERM_TIMEOUT_S wait before
+                # the SIGKILL escalation reaps the process. Acceptable —
+                # error paths are rare and the delay is bounded by the
+                # configured timeout.
+                await _reap_browser_process(proc)
 
     def stop(self) -> None:
         """Stop the browser and release resources.

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -948,3 +948,75 @@ class TestNoDriverExpectedStopPatterns:
         """Unexpected patterns are correctly identified."""
         backend = NoDriverBackend()
         assert backend._is_expected_stop_error(pattern) is False
+
+
+class TestNoDriverBackendStopReap:
+    """Tests that NoDriverBackend.stop() reaps the Chrome subprocess.
+
+    nodriver's Browser.stop() sends SIGTERM but never awaits proc.wait(),
+    leaving Chrome as a zombie under the live python parent. The backend's
+    _stop_async() compensates by awaiting the subprocess after browser.stop()
+    via the _reap_browser_process helper.
+    """
+
+    @staticmethod
+    def _make_proc(
+        wait_behavior: list,
+        kill_raises: BaseException | None = None,
+    ) -> MagicMock:
+        """Build a MagicMock asyncio subprocess.
+
+        wait_behavior: list consumed in order on each .wait() call. Each entry
+            is either an int (returned exit code), an Exception (raised), or
+            the string "block" (wait blocks until cancelled by wait_for).
+        kill_raises: if not None, .kill() raises this exception.
+        """
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.wait_call_count = 0
+        proc.kill_called = False
+        results_iter = iter(wait_behavior)
+
+        async def fake_wait():
+            proc.wait_call_count += 1
+            r = next(results_iter)
+            if r == "block":
+                import asyncio as _asyncio
+                await _asyncio.Event().wait()
+            if isinstance(r, BaseException):
+                raise r
+            return r
+
+        def fake_kill():
+            proc.kill_called = True
+            if kill_raises is not None:
+                raise kill_raises
+
+        proc.wait = fake_wait
+        proc.kill = fake_kill
+        return proc
+
+    @staticmethod
+    def _make_browser(proc: MagicMock | None) -> MagicMock:
+        """Build a MagicMock Browser whose .stop() nulls _process (matches
+        nodriver's real behavior in core/browser.py:718)."""
+        browser = MagicMock()
+        browser._process = proc
+
+        def fake_stop():
+            browser._process = None
+
+        browser.stop = fake_stop
+        return browser
+
+    async def test_stop_async_reaps_process(self) -> None:
+        """_stop_async awaits proc.wait() so the kernel reaps Chrome."""
+        proc = self._make_proc(wait_behavior=[0])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        await backend._stop_async()
+
+        assert proc.wait_call_count == 1, "proc.wait() should have been awaited exactly once"
+        assert proc.kill_called is False, "kill() should not be needed on success"

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1030,3 +1030,13 @@ class TestNoDriverBackendStopReap:
 
         # Should not raise (no proc to read, helper not called).
         await backend._stop_async()
+
+    async def test_stop_async_handles_browser_with_no_process(self) -> None:
+        """If start() raised between Browser construction and subprocess
+        spawn, _browser._process is None. Helper must no-op cleanly."""
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc=None)
+
+        # Should not raise.
+        await backend._stop_async()

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1062,3 +1062,27 @@ class TestNoDriverBackendStopReap:
         # after stop(), it would have received None and skipped wait() —
         # which is exactly the bug this test guards against.
         assert backend._browser._process is None
+
+    async def test_stop_async_escalates_to_sigkill_on_term_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When SIGTERM times out, helper escalates to SIGKILL and re-waits."""
+        # Tighten timeouts so the test runs in milliseconds.
+        monkeypatch.setattr(
+            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
+        )
+        monkeypatch.setattr(
+            "graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05
+        )
+
+        # First wait blocks (simulates Chrome ignoring SIGTERM); second wait
+        # returns immediately (simulates exit after SIGKILL).
+        proc = self._make_proc(wait_behavior=["block", 0])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        await backend._stop_async()
+
+        assert proc.wait_call_count == 2, "Expected two wait() calls (SIGTERM + SIGKILL)"
+        assert proc.kill_called is True, "kill() should have been called after SIGTERM timeout"

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1020,3 +1020,13 @@ class TestNoDriverBackendStopReap:
 
         assert proc.wait_call_count == 1, "proc.wait() should have been awaited exactly once"
         assert proc.kill_called is False, "kill() should not be needed on success"
+
+    async def test_stop_async_no_op_when_no_browser(self) -> None:
+        """_stop_async returns immediately when _browser is None — helper
+        is not invoked at all. Regression test for the early-return guard."""
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = None
+
+        # Should not raise (no proc to read, helper not called).
+        await backend._stop_async()

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1040,3 +1040,25 @@ class TestNoDriverBackendStopReap:
 
         # Should not raise.
         await backend._stop_async()
+
+    async def test_stop_async_captures_proc_before_browser_stop_nulls_it(self) -> None:
+        """_stop_async must capture _browser._process BEFORE calling stop().
+
+        nodriver's Browser.stop() resets self._process = None inside its
+        cleanup loop. If our backend reads _process AFTER stop(), it gets
+        None and the helper no-ops, leaving the subprocess as a zombie.
+        """
+        proc = self._make_proc(wait_behavior=[0])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        await backend._stop_async()
+
+        assert proc.wait_call_count == 1, (
+            "wait() not awaited — capture-before-stop ordering may be broken"
+        )
+        # Sanity: fake_stop nulled _process. If our backend read _process
+        # after stop(), it would have received None and skipped wait() —
+        # which is exactly the bug this test guards against.
+        assert backend._browser._process is None

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1120,3 +1120,34 @@ class TestNoDriverBackendStopReap:
             and e.get("log_level") == "warning"
             for e in cap
         ), f"expected warning event in captured logs: {cap}"
+
+    async def test_stop_async_handles_process_lookup_race(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ProcessLookupError on kill() is a successful reap (race-tight).
+
+        SIGTERM wait timed out; Chrome exited in the window between the
+        wait_for timeout and our kill() call. kill() raises
+        ProcessLookupError because the PID is gone. This is success — the
+        process IS reaped, the wait_for just missed the exit by microseconds.
+        """
+        monkeypatch.setattr(
+            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
+        )
+
+        # First wait blocks; kill raises ProcessLookupError; helper returns
+        # without making a second wait call.
+        proc = self._make_proc(
+            wait_behavior=["block"], kill_raises=ProcessLookupError(3, "No such process")
+        )
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        # Should not raise.
+        await backend._stop_async()
+
+        assert proc.wait_call_count == 1, (
+            "Helper should not call wait() a second time after ProcessLookupError"
+        )
+        assert proc.kill_called is True

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 
 from graftpunk.backends import get_backend, list_backends
 from graftpunk.backends.nodriver import NoDriverBackend
@@ -1086,3 +1087,36 @@ class TestNoDriverBackendStopReap:
 
         assert proc.wait_call_count == 2, "Expected two wait() calls (SIGTERM + SIGKILL)"
         assert proc.kill_called is True, "kill() should have been called after SIGTERM timeout"
+
+    async def test_stop_async_logs_when_sigkill_also_times_out(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When even SIGKILL doesn't unblock wait(), log a warning and return."""
+        monkeypatch.setattr(
+            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
+        )
+        monkeypatch.setattr(
+            "graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05
+        )
+
+        # Both wait() calls block — simulates a kernel-level wedge.
+        proc = self._make_proc(wait_behavior=["block", "block"])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        with capture_logs() as cap:
+            await backend._stop_async()
+
+        assert proc.wait_call_count == 2
+        assert proc.kill_called is True
+        # capture_logs() returns event_dicts where 'log_level' is the level
+        # key (structlog's testing processor normalises method name → log_level)
+        # and 'event' is the event string.
+        assert any(
+            e.get("event") == "chrome_failed_to_exit_after_sigkill"
+            and e.get("pid") == proc.pid
+            and e.get("log_level") == "warning"
+            for e in cap
+        ), f"expected warning event in captured logs: {cap}"

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -983,6 +983,7 @@ class TestNoDriverBackendStopReap:
             r = next(results_iter)
             if r == "block":
                 import asyncio as _asyncio
+
                 await _asyncio.Event().wait()
             if isinstance(r, BaseException):
                 raise r
@@ -1069,12 +1070,8 @@ class TestNoDriverBackendStopReap:
     ) -> None:
         """When SIGTERM times out, helper escalates to SIGKILL and re-waits."""
         # Tighten timeouts so the test runs in milliseconds.
-        monkeypatch.setattr(
-            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
-        )
-        monkeypatch.setattr(
-            "graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05
-        )
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05)
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05)
 
         # First wait blocks (simulates Chrome ignoring SIGTERM); second wait
         # returns immediately (simulates exit after SIGKILL).
@@ -1093,12 +1090,8 @@ class TestNoDriverBackendStopReap:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When even SIGKILL doesn't unblock wait(), log a warning and return."""
-        monkeypatch.setattr(
-            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
-        )
-        monkeypatch.setattr(
-            "graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05
-        )
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05)
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05)
 
         # Both wait() calls block — simulates a kernel-level wedge.
         proc = self._make_proc(wait_behavior=["block", "block"])
@@ -1131,9 +1124,7 @@ class TestNoDriverBackendStopReap:
         ProcessLookupError because the PID is gone. This is success — the
         process IS reaped, the wait_for just missed the exit by microseconds.
         """
-        monkeypatch.setattr(
-            "graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05
-        )
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05)
 
         # First wait blocks; kill raises ProcessLookupError; helper returns
         # without making a second wait call.

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1,5 +1,6 @@
 """Tests for NoDriver browser backend."""
 
+import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -963,17 +964,20 @@ class TestNoDriverBackendStopReap:
     @staticmethod
     def _make_proc(
         wait_behavior: list,
-        kill_raises: BaseException | None = None,
+        kill_raises: OSError | None = None,
     ) -> MagicMock:
         """Build a MagicMock asyncio subprocess.
 
         wait_behavior: list consumed in order on each .wait() call. Each entry
             is either an int (returned exit code), an Exception (raised), or
             the string "block" (wait blocks until cancelled by wait_for).
-        kill_raises: if not None, .kill() raises this exception.
+        kill_raises: if not None, .kill() raises this OSError. Typed as
+            OSError because the helper only handles ProcessLookupError and
+            other OSError subclasses on the kill path.
         """
         proc = MagicMock()
         proc.pid = 12345
+        proc.returncode = None
         proc.wait_call_count = 0
         proc.kill_called = False
         results_iter = iter(wait_behavior)
@@ -982,9 +986,7 @@ class TestNoDriverBackendStopReap:
             proc.wait_call_count += 1
             r = next(results_iter)
             if r == "block":
-                import asyncio as _asyncio
-
-                await _asyncio.Event().wait()
+                await asyncio.Event().wait()
             if isinstance(r, BaseException):
                 raise r
             return r
@@ -1157,3 +1159,56 @@ class TestNoDriverBackendStopReap:
         backend.stop()  # sync path
 
         assert proc.wait_call_count == 1, "sync stop() should also reap via _stop_async"
+
+    async def test_stop_async_public_api_reaps_process(self) -> None:
+        """The public async stop_async() inherits the reap via _stop_async.
+
+        Symmetric regression guard to test_sync_stop_also_reaps_process —
+        BrowserSession.__aexit__ calls stop_async() (not _stop_async()),
+        so the public path is production-critical.
+        """
+        proc = self._make_proc(wait_behavior=[0])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        await backend.stop_async()
+
+        assert proc.wait_call_count == 1, "stop_async() should reap via _stop_async"
+
+    async def test_stop_async_still_reaps_when_browser_stop_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If browser.stop() raises a handled error, the reap still runs.
+
+        Locks the documented edge case from _stop_async's inline comment:
+        even when browser.stop() raises (and is swallowed by
+        _handle_stop_error), the try/finally must still drive
+        _reap_browser_process so the subprocess is collected. Without the
+        finally, a stop()-side exception would leak the very subprocess
+        the reap exists to collect.
+        """
+        # Tighten timeouts so SIGTERM-then-SIGKILL completes in milliseconds.
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_TERM_TIMEOUT_S", 0.05)
+        monkeypatch.setattr("graftpunk.backends.nodriver._REAP_KILL_TIMEOUT_S", 0.05)
+
+        # First wait blocks (no SIGTERM was sent because stop() raised);
+        # second wait returns 0 after our SIGKILL escalation.
+        proc = self._make_proc(wait_behavior=["block", 0])
+        backend = NoDriverBackend()
+        backend._started = True
+        browser = self._make_browser(proc)
+
+        def raising_stop() -> None:
+            raise RuntimeError("browser is already closed")
+
+        browser.stop = raising_stop
+        backend._browser = browser
+
+        # Should not raise (RuntimeError caught by _handle_stop_error).
+        await backend._stop_async()
+
+        assert proc.kill_called is True, (
+            "SIGKILL escalation should reap the process when browser.stop() raised"
+        )
+        assert proc.wait_call_count == 2, "Both wait() calls (SIGTERM + SIGKILL) should have run"

--- a/tests/unit/test_nodriver_backend.py
+++ b/tests/unit/test_nodriver_backend.py
@@ -1151,3 +1151,18 @@ class TestNoDriverBackendStopReap:
             "Helper should not call wait() a second time after ProcessLookupError"
         )
         assert proc.kill_called is True
+
+    def test_sync_stop_also_reaps_process(self) -> None:
+        """The sync stop() path inherits the reap via _run_async->_stop_async.
+
+        Regression guard against a future refactor that splits the sync and
+        async stop paths and forgets to wire the reap into both.
+        """
+        proc = self._make_proc(wait_behavior=[0])
+        backend = NoDriverBackend()
+        backend._started = True
+        backend._browser = self._make_browser(proc)
+
+        backend.stop()  # sync path
+
+        assert proc.wait_call_count == 1, "sync stop() should also reap via _stop_async"


### PR DESCRIPTION
## Summary
- nodriver's `Browser.stop()` calls `proc.terminate()` (or `proc.kill()` as fallback) and sets `self._process = None` without ever awaiting `proc.wait()`. asyncio child processes must be `wait()`ed for the kernel to collect their exit status; otherwise they accumulate as `<defunct>` (zombie) entries under the live python parent.
- Add a module-level `_reap_browser_process(proc)` helper that awaits the subprocess with a SIGTERM→SIGKILL escalation (3s, then 1s). Call it from `_stop_async()` after `_deregister_browser()`. Sync `stop()` and async `stop_async()` both flow through `_stop_async()` and inherit the fix.
- Capture `_browser._process` *before* `browser.stop()` because nodriver's `stop()` nulls it inside its cleanup loop.

## Why this isn't a nodriver fix
nodriver's issue tracker is restricted (per the comment on the existing `_patch_nodriver_cookie_parsing()` workaround in this same file). Graftpunk core already absorbs nodriver workarounds locally; this is the same pattern.

## Test plan
- [x] Unit tests in `tests/unit/test_nodriver_backend.py::TestNoDriverBackendStopReap` cover: success path, SIGTERM-timeout escalation, SIGKILL-also-timeout warning, ProcessLookupError race on kill, no-browser early-return, browser-set-but-no-process state, capture-before-stop ordering, sync `stop()` regression.
- [x] No real Chrome subprocess is spawned in tests (mocks-only, in line with the existing test file).
- [x] `ruff check`, `ruff format --check` clean.
- [x] Full `pytest` suite passes (2099 tests).

Closes #127. See also #96 (complementary — covers abnormal-exit orphans).