### PR TITLE
chore: bump version to 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2026-05-05
+
+### Fixed
+
+- **Chrome subprocesses leaked as zombies under live python parents** — `NoDriverBackend._stop_async()` now awaits the Chrome subprocess after `browser.stop()` so the kernel can collect its exit status. Without this, nodriver's `Browser.stop()` sends SIGTERM but never `await`s `proc.wait()`, leaving Chrome as a `<defunct>` entry under the parent until that parent exits. In a docker container with `init: true`, docker-init can't help because the parent is alive — init only reaps processes whose parent has died. The fix adds a module-level `_reap_browser_process()` helper with SIGTERM→SIGKILL escalation (3s, then 1s) and a final warning log on kernel-level wedge. The reap runs in a `try/finally` so it always executes even when `browser.stop()` itself raises. Closes #127. See also #96 (complementary — covers abnormal-exit orphans).
+
 ## [1.8.1] - 2026-03-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.8.1"
+version = "1.8.2"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -47,7 +47,7 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
Bump version 1.8.1 → 1.8.2 (pyproject.toml, __init__.py, uv.lock)