### PR TITLE
fix(login): absolute login_config.url + browser_executable_path knob (closes #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-07-16
+
+### Added
+
+- **`GRAFTPUNK_BROWSER_EXECUTABLE_PATH` setting** — point the nodriver login browser at a specific Chrome/Chromium binary (e.g. Chrome-for-Testing) on machines/CI without a system Chrome install. `BrowserSession` forwards it to the nodriver backend's `browser_executable_path` option. Refs #132.
+
+### Fixed
+
+- **Login engine couldn't navigate to an absolute `login_config.url` (login host != API `base_url`)** — the login URL was built as `f"{base_url}{login_url}"`, assuming `login_config.url` is a path to append. That produced a malformed URL for a plugin whose login form is on a different host than its API `base_url`. The engine now uses `login_config.url` directly when it is absolute (and joins it onto `base_url` otherwise), in both the nodriver and selenium login generators. Closes #132.
+
 ## [1.8.2] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Login engine couldn't navigate to an absolute `login_config.url` (login host != API `base_url`)** — the login URL was built as `f"{base_url}{login_url}"`, assuming `login_config.url` is a path to append. That produced a malformed URL for a plugin whose login form is on a different host than its API `base_url`. The engine now uses `login_config.url` directly when it is absolute (and joins it onto `base_url` otherwise), in both the nodriver and selenium login generators. Closes #132.
+- **Login engine couldn't navigate to an absolute `login_config.url` (login host != API `base_url`)** — the login URL was built as `f"{base_url}{login_url}"`, assuming `login_config.url` is a path to append. That produced a malformed URL for a plugin whose login form is on a different host than its API `base_url`. A shared `_resolve_url` helper now uses an absolute URL as-is (any scheme) and joins a path onto `base_url` otherwise — applied to the login URL in both the nodriver and selenium generators (including the timeout-error message), and to token-extraction page URLs, which had the same latent bug. Closes #132.
 
 ## [1.8.2] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ gp import-har auth-flow.har --name mybank
 | `GRAFTPUNK_SESSION_TTL_HOURS` | `720` | Session lifetime (30 days) |
 | `GRAFTPUNK_LOG_LEVEL` | `WARNING` | Logging verbosity |
 | `GRAFTPUNK_LOG_FORMAT` | `console` | Log format: `console` or `json` |
+| `GRAFTPUNK_BROWSER_EXECUTABLE_PATH` | _(system Chrome)_ | Path to a Chrome/Chromium binary for the `nodriver` backend (e.g. Chrome-for-Testing on machines/CI without a system Chrome install) |
 
 CLI flags: `-v` (info), `-vv` (debug), `--log-format json`, `--observe full`, `--network-debug` (wire-level HTTP tracing).
 
@@ -370,6 +371,8 @@ from graftpunk import BrowserSession
 # Use BrowserSession with explicit backend
 session = BrowserSession(backend="nodriver", headless=False)
 ```
+
+**Custom Chrome binary:** the `nodriver` backend auto-detects a system Chrome. Set `GRAFTPUNK_BROWSER_EXECUTABLE_PATH` to point it at a specific Chrome/Chromium binary (e.g. Chrome-for-Testing) on machines or CI without a system Chrome install.
 
 ## Security
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -334,7 +334,7 @@ Each step in a login flow can include:
 The top-level login configuration includes:
 
 - **`steps`** — Required list of `LoginStep` objects defining the login flow.
-- **`url`** — Optional login page path (appended to `base_url`).
+- **`url`** — Optional login page path (appended to `base_url`), or an absolute URL (used as-is) when the login form lives on a different host than `base_url`.
 - **`wait_for`** — Optional top-level wait for element before any steps begin.
 - **`failure`** — Optional text that indicates login failure.
 - **`success`** — Optional CSS selector that indicates login success.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.8.2"
+version = "1.9.0"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -79,6 +79,16 @@ class GraftpunkSettings(BaseSettings):
         description="Base delay in seconds for exponential backoff",
     )
 
+    browser_executable_path: str | None = Field(
+        default=None,
+        description=(
+            "Path to a Chrome/Chromium binary for the nodriver backend. When set, "
+            "browser sessions use it instead of the system Chrome auto-detection — "
+            "e.g. point at a Chrome-for-Testing binary on machines/CI without a "
+            "system Chrome install."
+        ),
+    )
+
     model_config = SettingsConfigDict(
         env_prefix="GRAFTPUNK_",
         env_file=".env",

--- a/src/graftpunk/plugins/cli_plugin.py
+++ b/src/graftpunk/plugins/cli_plugin.py
@@ -485,8 +485,9 @@ class LoginConfig:
     Attributes:
         steps: Sequence of LoginStep objects to execute (list or tuple accepted).
             Required and non-empty. Input is converted to tuple for immutability.
-        url: Login page path (appended to base_url). Empty string (default)
-            means use base_url directly.
+        url: Login page path (appended to base_url), or an absolute URL (used
+            as-is) when the login form is on a different host than base_url.
+            Empty string (default) means use base_url directly.
         failure: Text on the page indicating login failure.
         success: CSS selector for an element indicating login success.
         wait_for: CSS selector to wait for before any steps execute.

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -343,17 +343,25 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
             )
         base_url = plugin.base_url.rstrip("/")
         login_url = plugin.login_config.url
+        # login_config.url may be an absolute URL (when the login host differs
+        # from the API base_url) or a path to append to base_url. Use it
+        # directly when absolute; otherwise join it onto base_url.
+        login_target = (
+            login_url
+            if login_url.startswith(("http://", "https://"))
+            else base_url + login_url
+        )
         failure_text = plugin.login_config.failure
 
         async with BrowserSession(backend="nodriver", headless=False) as session:
             try:
                 async with asyncio.timeout(_LOGIN_NAV_TIMEOUT):
-                    tab = await session.driver.get(f"{base_url}{login_url}")
+                    tab = await session.driver.get(login_target)
             except TimeoutError:
                 LOG.error(
                     "login_page_navigation_timeout",
                     plugin=plugin.site_name,
-                    url=f"{base_url}{login_url}",
+                    url=login_target,
                     timeout=_LOGIN_NAV_TIMEOUT,
                 )
                 raise PluginError(
@@ -450,12 +458,12 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
             # Capture current URL before caching (used for domain display)
             try:
                 if tab and hasattr(tab, "url"):
-                    session.current_url = tab.url or f"{base_url}{login_url}"
+                    session.current_url = tab.url or login_target
                 else:
-                    session.current_url = f"{base_url}{login_url}"
+                    session.current_url = login_target
             except Exception as exc:  # noqa: BLE001 — URL is optional metadata for display
                 LOG.debug("login_url_capture_failed", error=str(exc), backend="nodriver")
-                session.current_url = f"{base_url}{login_url}"
+                session.current_url = login_target
 
             # Extract header roles from captured network requests
             session._gp_header_roles = _header_capture.get_header_roles()
@@ -492,6 +500,14 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
             )
         base_url = plugin.base_url.rstrip("/")
         login_url = plugin.login_config.url
+        # login_config.url may be an absolute URL (when the login host differs
+        # from the API base_url) or a path to append to base_url. Use it
+        # directly when absolute; otherwise join it onto base_url.
+        login_target = (
+            login_url
+            if login_url.startswith(("http://", "https://"))
+            else base_url + login_url
+        )
         failure_text = plugin.login_config.failure
         success_selector = plugin.login_config.success
 
@@ -502,7 +518,7 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
             _header_capture = create_capture_backend("selenium", session.driver)
             _header_capture.start_capture()
 
-            session.driver.get(f"{base_url}{login_url}")
+            session.driver.get(login_target)
 
             # Top-level wait_for is not supported for selenium
             if plugin.login_config.wait_for:
@@ -581,7 +597,7 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
                 session.current_url = session.driver.current_url
             except Exception as exc:  # noqa: BLE001 — URL is optional metadata for display
                 LOG.debug("login_url_capture_failed", error=str(exc), backend="selenium")
-                session.current_url = f"{base_url}{login_url}"
+                session.current_url = login_target
 
             # Stop capture to parse perf log, then extract roles
             _header_capture.stop_capture()

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from graftpunk import BrowserSession, cache_session
@@ -25,6 +26,28 @@ _POST_SUBMIT_DELAY = 3  # seconds to wait after form submission for page to sett
 _ELEMENT_WAIT_TIMEOUT = 30  # seconds to wait for element during page transitions
 _ELEMENT_RETRY_INTERVAL = 1.0  # seconds between retry attempts
 _LOGIN_NAV_TIMEOUT = 60  # seconds — login page may redirect through SSO/IdP chains
+
+
+def _resolve_url(base_url: str, url: str) -> str:
+    """Resolve a configured plugin URL against ``base_url``.
+
+    A ``LoginConfig.url`` or a token page URL may be either a path appended to
+    ``base_url`` (the common same-host case) or an **absolute** URL, used as-is,
+    when the target host differs from the API ``base_url`` (e.g. a login form on
+    ``www.example.com`` while the API ``base_url`` is ``api.example.com``). An
+    empty string yields ``base_url`` itself.
+
+    Args:
+        base_url: The plugin's API base URL (no trailing slash).
+        url: A path (``/login``), an absolute URL (``https://host/login``), or
+            an empty string.
+
+    Returns:
+        The absolute URL to navigate to.
+    """
+    # Absolute when it carries a scheme (http/https, any case — urlsplit
+    # lower-cases the scheme). Otherwise treat it as a path onto base_url.
+    return url if urllib.parse.urlsplit(url).scheme else f"{base_url}{url}"
 
 
 # TODO: Replace Any type annotations with proper nodriver.Tab / nodriver.Element
@@ -289,7 +312,7 @@ def _extract_and_cache_tokens_selenium(
                 token_results[t.name] = val
         elif t.source == "page" and t.pattern:
             try:
-                session.driver.get(f"{base_url}{t.page_url}")
+                session.driver.get(_resolve_url(base_url, t.page_url))
                 time.sleep(2)
                 match = re.search(t.pattern, session.driver.page_source)
                 if match:
@@ -298,7 +321,7 @@ def _extract_and_cache_tokens_selenium(
                     LOG.warning(
                         "login_token_pattern_not_found",
                         token=t.name,
-                        url=f"{base_url}{t.page_url}",
+                        url=_resolve_url(base_url, t.page_url),
                     )
             except Exception as exc:  # noqa: BLE001 — best-effort token extraction
                 LOG.warning("login_token_extraction_failed", token=t.name, error=str(exc))
@@ -343,14 +366,7 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
             )
         base_url = plugin.base_url.rstrip("/")
         login_url = plugin.login_config.url
-        # login_config.url may be an absolute URL (when the login host differs
-        # from the API base_url) or a path to append to base_url. Use it
-        # directly when absolute; otherwise join it onto base_url.
-        login_target = (
-            login_url
-            if login_url.startswith(("http://", "https://"))
-            else base_url + login_url
-        )
+        login_target = _resolve_url(base_url, login_url)
         failure_text = plugin.login_config.failure
 
         async with BrowserSession(backend="nodriver", headless=False) as session:
@@ -367,7 +383,7 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
                 raise PluginError(
                     f"Timed out loading login page ({_LOGIN_NAV_TIMEOUT}s). "
                     f"The site may be unreachable or blocked by a WAF. "
-                    f"URL: {base_url}{login_url}"
+                    f"URL: {login_target}"
                 ) from None
 
             # Start header capture for role extraction (lightweight, no body fetching)
@@ -500,14 +516,7 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
             )
         base_url = plugin.base_url.rstrip("/")
         login_url = plugin.login_config.url
-        # login_config.url may be an absolute URL (when the login host differs
-        # from the API base_url) or a path to append to base_url. Use it
-        # directly when absolute; otherwise join it onto base_url.
-        login_target = (
-            login_url
-            if login_url.startswith(("http://", "https://"))
-            else base_url + login_url
-        )
+        login_target = _resolve_url(base_url, login_url)
         failure_text = plugin.login_config.failure
         success_selector = plugin.login_config.success
 

--- a/src/graftpunk/session.py
+++ b/src/graftpunk/session.py
@@ -121,7 +121,16 @@ class BrowserSession(requestium.Session):
             # Call await session.start_async() in async context before using the driver.
             LOG.info("creating_nodriver_browser_session", headless=headless)
             try:
-                self._backend_instance = get_backend("nodriver", headless=headless)
+                from graftpunk.config import get_settings
+
+                nodriver_opts: dict[str, Any] = {"headless": headless}
+                # Allow pointing nodriver at a specific Chrome/Chromium binary
+                # (e.g. Chrome-for-Testing) via GRAFTPUNK_BROWSER_EXECUTABLE_PATH,
+                # for machines/CI without a system Chrome install.
+                browser_path = get_settings().browser_executable_path
+                if browser_path:
+                    nodriver_opts["browser_executable_path"] = browser_path
+                self._backend_instance = get_backend("nodriver", **nodriver_opts)
 
                 # Initialize minimal session (no driver creation)
                 import requests

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -123,3 +123,20 @@ class TestSessionsDir:
         settings = get_settings()
         assert settings.sessions_dir.exists()
         assert settings.sessions_dir.is_dir()
+
+
+class TestBrowserExecutablePath:
+    """Tests for the GRAFTPUNK_BROWSER_EXECUTABLE_PATH setting."""
+
+    def test_default_is_none(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)  # avoid picking up a project .env
+        monkeypatch.delenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", raising=False)
+        reset_settings()
+        assert get_settings().browser_executable_path is None
+
+    def test_read_from_env(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", "/opt/chrome-for-testing/chrome")
+        reset_settings()
+        assert get_settings().browser_executable_path == "/opt/chrome-for-testing/chrome"
+        reset_settings()

--- a/tests/unit/test_login_engine.py
+++ b/tests/unit/test_login_engine.py
@@ -2112,3 +2112,33 @@ class TestSeleniumMultiStepLogin:
         # Clicks: 2 field clicks + 1 submit click = 3
         # (Step 1 has no submit, Step 2 has submit)
         assert click_count == 3
+
+
+class TestResolveUrl:
+    """Tests for _resolve_url — login/token URL resolution against base_url."""
+
+    def test_relative_path_joined_onto_base_url(self):
+        from graftpunk.plugins.login_engine import _resolve_url
+
+        assert _resolve_url("https://api.example.com", "/login") == "https://api.example.com/login"
+
+    def test_empty_url_yields_base_url(self):
+        from graftpunk.plugins.login_engine import _resolve_url
+
+        assert _resolve_url("https://api.example.com", "") == "https://api.example.com"
+
+    def test_absolute_url_on_different_host_used_as_is(self):
+        # The bug this guards: login host differs from the API base_url, so the
+        # absolute login_config.url must be used directly, not concatenated.
+        from graftpunk.plugins.login_engine import _resolve_url
+
+        assert (
+            _resolve_url("https://embedded.example.com", "https://www.example.com/login")
+            == "https://www.example.com/login"
+        )
+
+    def test_absolute_http_and_uppercase_scheme_used_as_is(self):
+        from graftpunk.plugins.login_engine import _resolve_url
+
+        assert _resolve_url("https://api.x.com", "http://login.x.com/") == "http://login.x.com/"
+        assert _resolve_url("https://api.x.com", "HTTPS://login.x.com/a") == "HTTPS://login.x.com/a"

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1894,3 +1894,32 @@ class TestBotCookieFiltering:
         assert "bm_" in BOT_DETECTION_COOKIE_PREFIXES
         assert "ak_bmsc" in BOT_DETECTION_COOKIE_PREFIXES
         assert "_abck" in BOT_DETECTION_COOKIE_PREFIXES
+
+
+class TestNodriverBrowserExecutablePath:
+    """BrowserSession forwards GRAFTPUNK_BROWSER_EXECUTABLE_PATH to the nodriver backend."""
+
+    def test_forwarded_when_set(self, monkeypatch):
+        from graftpunk.config import reset_settings
+        from graftpunk.session import BrowserSession
+
+        monkeypatch.setenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", "/opt/cft/chrome")
+        reset_settings()
+        # get_backend is imported inside BrowserSession.__init__ from graftpunk.backends
+        with patch("graftpunk.backends.get_backend") as gb:
+            BrowserSession(backend="nodriver", headless=True)
+        _, kwargs = gb.call_args
+        assert kwargs.get("browser_executable_path") == "/opt/cft/chrome"
+        reset_settings()
+
+    def test_absent_when_unset(self, monkeypatch):
+        from graftpunk.config import reset_settings
+        from graftpunk.session import BrowserSession
+
+        monkeypatch.delenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", raising=False)
+        reset_settings()
+        with patch("graftpunk.backends.get_backend") as gb:
+            BrowserSession(backend="nodriver", headless=True)
+        _, kwargs = gb.call_args
+        assert "browser_executable_path" not in kwargs
+        reset_settings()


### PR DESCRIPTION
Closes #132.

Two limitations in the declarative login engine, both surfaced by the ShopKeep plugin (first plugin whose login host differs from its API `base_url`, running on a machine without system Chrome).

## Item 1 — absolute `login_config.url` (host ≠ `base_url`)
The engine built the login URL as `f"{base_url}{login_url}"`, assuming `login_config.url` is a path. That breaks a plugin whose login host differs from its API host — shopkeep (`base_url` `embedded.shopkeepapp.com`, login `https://www.shopkeepapp.com/login`) yielded the malformed `https://embedded.shopkeepapp.comhttps://www.shopkeepapp.com/login`.
**Fix:** resolve `login_target` (use `login_config.url` directly when absolute, else join onto `base_url`) in both the nodriver and selenium generators.

## Item 2 — point the login browser at a specific Chrome binary
The login path hard-codes `BrowserSession(backend="nodriver", headless=False)` with no options, so on a machine without a system Chrome, nodriver raises `could not find a valid chrome browser binary`.
**Fix:** add a `browser_executable_path` setting (env `GRAFTPUNK_BROWSER_EXECUTABLE_PATH`), forwarded by `BrowserSession` to the nodriver backend's existing `browser_executable_path` option. Point it at e.g. Chrome-for-Testing on Chrome-less machines/CI.

## Verified end-to-end (Python 3.13, real ShopKeep store)
- With Item 1 + `GRAFTPUNK_BROWSER_EXECUTABLE_PATH=<Chrome-for-Testing>` (no code patches), a hands-off `shopkeep` login returned **`True`**, cached a fresh session; the session then worked live (`export list` → 3 rows, `reorder` → ~4,960-line CSV).
- ruff clean; modules parse; all `f"{base_url}{login_url}"` use-sites now use `login_target`.
- The `tests/unit/test_login_engine_retry.py` failures are pre-existing (graftpunk's `.venv` is Python 3.14, where `import nodriver` 0.50.3 raises `SyntaxError`) — identical on `main`, unrelated to this change.

_Known separate concern (not this PR): nodriver's success-detection against ShopKeep's heavy dashboard is occasionally flaky; a re-run succeeds._
