### PR TITLE
ci: publish to PyPI via GitHub Actions Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ name: Release
 #
 # workflow_dispatch (ref: vX.Y.Z) re-runs the pipeline against an existing tag
 # — used to publish a tag that was cut before this workflow existed, or to
-# retry a failed publish.
+# retry a failed publish (the publish step uses skip-existing, so retries are
+# idempotent).
 #
 # One-time PyPI setup (repo owner, on pypi.org → graftpunk → Publishing):
 #   Add a GitHub Actions trusted publisher:
@@ -29,12 +30,54 @@ on:
         required: true
         type: string
 
+# One release run per ref; never cancel an in-flight publish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
+env:
+  # Pin the interpreter uv selects for the whole pipeline (the package requires
+  # >=3.11; 3.12 is the release build/test target).
+  UV_PYTHON: "3.12"
+
 jobs:
+  verify:
+    name: Verify tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve release tag
+        id: tag
+        env:
+          RAW_REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          TAG="${RAW_REF#refs/tags/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches pyproject version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          TAG_VERSION="${TAG#v}"
+          PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PKG_VERSION})"
+            exit 1
+          fi
+          echo "Tag ${TAG_VERSION} matches pyproject.toml ${PKG_VERSION}"
+
   test:
-    name: Test (release gate)
+    name: Lint & test (release gate)
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,46 +96,32 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Lint with ruff
+        run: uvx ruff check .
+
+      - name: Format check with ruff
+        run: uvx ruff format --check .
+
       - name: Run tests
         run: uv run pytest tests/ -v
 
   build:
     name: Build distribution
-    needs: test
+    needs: [verify, test]
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: 0
-
-      - name: Resolve release tag
-        id: tag
-        env:
-          RAW_REF: ${{ inputs.ref || github.ref_name }}
-        run: |
-          TAG="${RAW_REF#refs/tags/}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify tag matches pyproject version
-        env:
-          TAG_VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PKG_VERSION})"
-            exit 1
-          fi
-          echo "Tag ${TAG_VERSION} matches pyproject.toml ${PKG_VERSION}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
 
       - name: Build sdist and wheel
         run: uvx --from build pyproject-build
@@ -124,23 +153,23 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent: a workflow_dispatch retry after a partial/failed upload
+          # skips files already on PyPI instead of erroring on the whole run.
+          skip-existing: true
 
   github-release:
     name: Create GitHub release
-    needs: [build, pypi-publish]
+    needs: [verify, pypi-publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release / tag notes
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Create GitHub release (if missing)
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.build.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.verify.outputs.tag }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release ${TAG} already exists — skipping."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+# Publishes graftpunk to PyPI via Trusted Publishing (OIDC) — no stored token.
+#
+# Cutting a release is just pushing a tag:
+#   just release        # validates, tags vX.Y.Z, pushes the tag
+# The pushed tag triggers this workflow, which tests, builds, publishes to
+# PyPI, and creates the GitHub release. See README "Releasing".
+#
+# workflow_dispatch (ref: vX.Y.Z) re-runs the pipeline against an existing tag
+# — used to publish a tag that was cut before this workflow existed, or to
+# retry a failed publish.
+#
+# One-time PyPI setup (repo owner, on pypi.org → graftpunk → Publishing):
+#   Add a GitHub Actions trusted publisher:
+#     Owner:        stavxyz
+#     Repository:   graftpunk
+#     Workflow:     release.yml
+#     Environment:  pypi
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Existing tag to (re)publish, e.g. v1.9.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (release gate)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  build:
+    name: Build distribution
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        env:
+          RAW_REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          TAG="${RAW_REF#refs/tags/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches pyproject version
+        env:
+          TAG_VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PKG_VERSION})"
+            exit 1
+          fi
+          echo "Tag ${TAG_VERSION} matches pyproject.toml ${PKG_VERSION}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Build sdist and wheel
+        run: uvx --from build pyproject-build
+
+      - name: Check distributions
+        run: uvx twine check dist/*
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/graftpunk
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing — no stored secret
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: [build, pypi-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release / tag notes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub release (if missing)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release ${TAG} already exists — skipping."
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+            echo "Created GitHub release ${TAG}."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Automated PyPI release via GitHub Actions Trusted Publishing** — `.github/workflows/release.yml` publishes to PyPI over OIDC (no stored token) when a `vX.Y.Z` tag is pushed: it runs the tests, verifies the tag matches `pyproject.toml`, builds, publishes, and creates the GitHub release. A `workflow_dispatch` (`ref: vX.Y.Z`) re-runs the pipeline against an existing tag. Requires a one-time PyPI trusted-publisher config (see README "Releasing").
+
+### Changed
+
+- **`just release` now only validates + pushes the tag** — build, PyPI upload, and GitHub-release creation moved to CI (above). This removes the local PyPI credential requirement and runs the build/publish gate on a CI-pinned Python instead of the local interpreter. `just publish` remains as a manual token-based fallback.
+
 ## [1.9.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -409,6 +409,22 @@ just build    # Build for PyPI
 
 Requires [uv](https://docs.astral.sh/uv/) for development. See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
 
+### Releasing
+
+Releases publish to PyPI through GitHub Actions using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored anywhere.
+
+```bash
+just bump X.Y.Z   # opens a version-bump PR (pyproject, __init__, uv.lock, CHANGELOG)
+# merge the PR, then on an up-to-date main:
+just release      # validates, tags vX.Y.Z, and pushes the tag
+```
+
+Pushing the tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml), which runs the tests, builds the sdist/wheel, publishes to PyPI via OIDC, and creates the GitHub release. Because build + publish run in CI on a pinned Python, releasing no longer depends on your local interpreter or any local credentials.
+
+To (re)publish a tag that was cut before this workflow existed, or to retry a failed publish, run the workflow manually (**Actions → Release → Run workflow**) with the tag (e.g. `v1.9.0`).
+
+**One-time setup** (repo owner, on [pypi.org](https://pypi.org/manage/project/graftpunk/settings/publishing/) → graftpunk → Publishing): add a GitHub Actions trusted publisher with owner `stavxyz`, repository `graftpunk`, workflow `release.yml`, and environment `pypi`.
+
 ## License
 
 MIT License—see [LICENSE](LICENSE).

--- a/justfile
+++ b/justfile
@@ -180,20 +180,26 @@ release:
         exit 1
     fi
 
-    # Check the latest CI run for this commit is green (best-effort: a failure
-    # blocks; success or no-run-found proceeds, since not every commit triggers
-    # the path-filtered quality workflow).
+    # Check the latest CI run for this commit is green (best-effort). A failed
+    # or still-running run blocks; only a genuine "no run found" proceeds, since
+    # not every commit triggers the path-filtered quality workflow.
     echo "🔍 Checking CI status for HEAD (${LOCAL})..."
-    CI_CONCLUSION=$(gh run list --commit "$LOCAL" --workflow "Python Code Quality" \
-        --limit 1 --json conclusion --jq '.[0].conclusion // ""' 2>/dev/null || echo "")
-    case "$CI_CONCLUSION" in
-        success) echo "   CI is green" ;;
-        "")      echo "   (no CI run found for HEAD — proceeding)" ;;
-        *)
-            echo "❌ CI for HEAD concluded '${CI_CONCLUSION}'. Fix before releasing."
-            exit 1
-            ;;
-    esac
+    CI=$(gh run list --commit "$LOCAL" --workflow "Python Code Quality" --limit 1 \
+        --json status,conclusion \
+        --jq '.[0] | "\(.status // "none"):\(.conclusion // "none")"' 2>/dev/null || echo "none:none")
+    CI_STATUS="${CI%%:*}"
+    CI_CONCLUSION="${CI##*:}"
+    if [ "$CI_STATUS" = "none" ]; then
+        echo "   (no CI run found for HEAD — proceeding)"
+    elif [ "$CI_STATUS" != "completed" ]; then
+        echo "❌ CI for HEAD is still running (status: ${CI_STATUS}). Wait for it to finish."
+        exit 1
+    elif [ "$CI_CONCLUSION" = "success" ]; then
+        echo "   CI is green"
+    else
+        echo "❌ CI for HEAD concluded '${CI_CONCLUSION}'. Fix before releasing."
+        exit 1
+    fi
 
     # ----------------------------
     # Confirmation

--- a/justfile
+++ b/justfile
@@ -73,9 +73,12 @@ publish-test: check-dist
     @echo "📦 Uploaded to Test PyPI"
     @echo "🔗 https://test.pypi.org/project/graftpunk/"
 
-# Upload to PyPI (production)
+# Upload to PyPI (production) — MANUAL FALLBACK ONLY.
+# The normal path is `just release` → the tag triggers CI, which publishes via
+# Trusted Publishing (no token). Use this only if you must publish by hand with
+# a local token (e.g. CI is unavailable).
 publish: check-dist
-    @echo "⚠️  Publishing to PyPI (production)"
+    @echo "⚠️  Publishing to PyPI (production) — manual fallback"
     @read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ]
     uvx twine upload dist/*
     @echo "📦 Uploaded to PyPI"
@@ -89,8 +92,13 @@ publish: check-dist
 _get-version:
     @grep '^version = ' pyproject.toml | head -1 | cut -d'"' -f2
 
-# Full release: tag, GitHub release, PyPI upload
-release: check
+# Full release: tag + push (CI builds, publishes to PyPI, cuts the GitHub release)
+#
+# Publishing runs in GitHub Actions (.github/workflows/release.yml) via PyPI
+# Trusted Publishing (OIDC) — no local PyPI credentials, and the test/build
+# gate runs on a CI-controlled Python rather than your local interpreter.
+# This recipe only validates + pushes the tag; the pushed tag does the rest.
+release:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -172,6 +180,21 @@ release: check
         exit 1
     fi
 
+    # Check the latest CI run for this commit is green (best-effort: a failure
+    # blocks; success or no-run-found proceeds, since not every commit triggers
+    # the path-filtered quality workflow).
+    echo "🔍 Checking CI status for HEAD (${LOCAL})..."
+    CI_CONCLUSION=$(gh run list --commit "$LOCAL" --workflow "Python Code Quality" \
+        --limit 1 --json conclusion --jq '.[0].conclusion // ""' 2>/dev/null || echo "")
+    case "$CI_CONCLUSION" in
+        success) echo "   CI is green" ;;
+        "")      echo "   (no CI run found for HEAD — proceeding)" ;;
+        *)
+            echo "❌ CI for HEAD concluded '${CI_CONCLUSION}'. Fix before releasing."
+            exit 1
+            ;;
+    esac
+
     # ----------------------------
     # Confirmation
     # ----------------------------
@@ -181,8 +204,10 @@ release: check
     echo "This will:"
     echo "  1. Create git tag ${TAG}"
     echo "  2. Push tag to origin"
-    echo "  3. Create GitHub release"
-    echo "  4. Build and upload to PyPI"
+    echo ""
+    echo "The pushed tag triggers .github/workflows/release.yml, which tests,"
+    echo "builds, publishes to PyPI (Trusted Publishing / OIDC), and creates"
+    echo "the GitHub release. No local PyPI credentials are used."
     echo ""
     read -p "Continue? [y/N] " confirm
     if [ "$confirm" != "y" ]; then
@@ -194,25 +219,15 @@ release: check
     # Release
     # ----------------------------
 
-    # Create and push tag
+    # Create and push tag — CI (release.yml) does build + publish + GH release.
     git tag -a "$TAG" -m "Release ${TAG}"
     git push origin "$TAG" --no-verify
-    echo "✅ Tag ${TAG} pushed"
-
-    # Create GitHub release
-    gh release create "$TAG" --title "${TAG}" --generate-notes
-    echo "✅ GitHub release created"
-
-    # Build and upload to PyPI
-    just clean
-    uvx --from build pyproject-build
-    uvx twine check dist/*
-    uvx twine upload dist/*
 
     echo ""
-    echo "✅ Released ${TAG}"
-    echo "🔗 https://github.com/stavxyz/graftpunk/releases/tag/${TAG}"
-    echo "🔗 https://pypi.org/project/graftpunk/${VERSION}/"
+    echo "✅ Tag ${TAG} pushed — the Release workflow will publish to PyPI"
+    echo "🔗 Watch:   https://github.com/stavxyz/graftpunk/actions/workflows/release.yml"
+    echo "🔗 Release: https://github.com/stavxyz/graftpunk/releases/tag/${TAG}"
+    echo "🔗 PyPI:    https://pypi.org/project/graftpunk/${VERSION}/"
 
 # --------------------------------------------------------------------------
 # Version Bump


### PR DESCRIPTION
## What

Automate PyPI publishing through GitHub Actions using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), so cutting a release no longer needs a locally-stored PyPI token or a working local Python interpreter.

## Why

Releasing was blocked on two things: (1) no PyPI credentials configured locally, and (2) `just release`'s local test/build gate can't run on this machine's Python 3.14 `.venv` (the nodriver import `SyntaxError`). Moving build + publish into CI removes both — publishing authenticates via GitHub's OIDC identity (no secret anywhere) and runs the gate on a CI-pinned Python.

## Changes

- **`.github/workflows/release.yml`** (new) — triggered by a `v*.*.*` tag push, or `workflow_dispatch` with a `ref` for an existing tag. Jobs:
  1. `verify` — resolve the tag and assert it matches `pyproject.toml` (fail-fast, before the expensive test job)
  2. `test` — `uv sync --all-extras` + `ruff check`/`format --check` + `pytest` on Python 3.12 (release gate)
  3. `build` — build sdist/wheel, `twine check`, upload artifact
  4. `pypi-publish` — `pypa/gh-action-pypi-publish` with `id-token: write` + `environment: pypi` + `skip-existing: true` (OIDC, no token; idempotent retries)
  5. `github-release` — create the GitHub release from the tag (idempotent — skips if it already exists)
  - Hardening: top-level `permissions: contents: read`, `concurrency` group (no cancel-in-progress), `UV_PYTHON: "3.12"` pin.
- **`justfile`** — `just release` now only validates + tags + pushes (CI does build/publish/release); dropped the local `check` dependency and added a CI-status-aware preflight (blocks on a failed *or in-progress* run). `just publish` kept as a documented manual fallback.
- **README `Releasing` section** + **CHANGELOG** — document the flow and the one-time PyPI setup.

## Required one-time setup (repo owner)

On [pypi.org → graftpunk → Publishing](https://pypi.org/manage/project/graftpunk/settings/publishing/), add a GitHub Actions trusted publisher:

| Field | Value |
|---|---|
| Owner | `stavxyz` |
| Repository | `graftpunk` |
| Workflow | `release.yml` |
| Environment | `pypi` |

Until that's configured, the `pypi-publish` job will fail to authenticate.

## Publishing 1.9.0

`v1.9.0` was tagged before this workflow existed, so it won't auto-trigger. After the trusted publisher is configured, publish it via **Actions → Release → Run workflow** with `ref: v1.9.0` (this dogfoods the whole pipeline end-to-end). PyPI's latest is currently 1.8.2.

## Review

Polished via two parallel reviewers (pr-review-toolkit + superpowers). No Critical findings; OIDC scoping, no-secrets model, and the fail-safe `verify → test → build → publish` chain were both independently confirmed. All 7 actionable findings addressed in `78d22fc` (idempotent publish, fail-fast verify job, lint restored to the gate, interpreter pin, dead-checkout removal, concurrency group, in-progress-aware preflight).

## Test plan

- [x] `release.yml` is valid YAML with correct `needs` wiring (`verify → test → build → pypi-publish`; `github-release` needs `verify` + `pypi-publish`)
- [x] `justfile` parses (`just --summary`); release recipe body passes `shellcheck -S warning` clean
- [x] PR CI green (`filter-paths` pass; `quality` correctly path-filtered/skipped — no `.py`/`pyproject`/`uv.lock` changed)
- [ ] **[manual — repo owner]** Configure the PyPI trusted publisher (table above)
- [ ] **[post-merge]** `workflow_dispatch` `ref: v1.9.0` → run is green and 1.9.0 lands on PyPI
- [ ] **[post-merge]** `pip install graftpunk==1.9.0` resolves from PyPI