### PR TITLE
fix: derive __version__ from package metadata (single source of truth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.1] - 2026-07-17
+
+### Fixed
+
+- **`graftpunk.__version__` no longer drifts from the packaged version** — it is now derived from the installed package metadata (`importlib.metadata.version`) instead of a hardcoded literal in `__init__.py`. The 1.9.0 release shipped `__version__ == "1.8.2"` because that release was bumped by hand and the `__init__.py` literal was missed; `pyproject.toml` is now the single source of truth, so this class of mismatch is unrepresentable. `just bump` no longer edits `__init__.py`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.9.1] - 2026-07-17
 
-### Fixed
-
-- **`graftpunk.__version__` no longer drifts from the packaged version** — it is now derived from the installed package metadata (`importlib.metadata.version`) instead of a hardcoded literal in `__init__.py`. The 1.9.0 release shipped `__version__ == "1.8.2"` because that release was bumped by hand and the `__init__.py` literal was missed; `pyproject.toml` is now the single source of truth, so this class of mismatch is unrepresentable. `just bump` no longer edits `__init__.py`.
-
 ### Added
 
 - **Automated PyPI release via GitHub Actions Trusted Publishing** — `.github/workflows/release.yml` publishes to PyPI over OIDC (no stored token) when a `vX.Y.Z` tag is pushed: it runs the tests, verifies the tag matches `pyproject.toml`, builds, publishes, and creates the GitHub release. A `workflow_dispatch` (`ref: vX.Y.Z`) re-runs the pipeline against an existing tag. Requires a one-time PyPI trusted-publisher config (see README "Releasing").
@@ -18,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`just release` now only validates + pushes the tag** — build, PyPI upload, and GitHub-release creation moved to CI (above). This removes the local PyPI credential requirement and runs the build/publish gate on a CI-pinned Python instead of the local interpreter. `just publish` remains as a manual token-based fallback.
+
+### Fixed
+
+- **`graftpunk.__version__` no longer drifts from the packaged version** — it is now derived from the installed package metadata (`importlib.metadata.version`) instead of a hardcoded literal in `__init__.py`. The 1.9.0 release shipped `__version__ == "1.8.2"` because that release was bumped by hand and the `__init__.py` literal was missed; `pyproject.toml` is now the single source of truth, so this class of mismatch is unrepresentable. `just bump` no longer edits `__init__.py`.
 
 ## [1.9.0] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Requires [uv](https://docs.astral.sh/uv/) for development. See [CONTRIBUTING.md]
 Releases publish to PyPI through GitHub Actions using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token is stored anywhere.
 
 ```bash
-just bump X.Y.Z   # opens a version-bump PR (pyproject, __init__, uv.lock, CHANGELOG)
+just bump X.Y.Z   # opens a version-bump PR (pyproject, uv.lock, CHANGELOG)
 # merge the PR, then on an up-to-date main:
 just release      # validates, tags vX.Y.Z, and pushes the tag
 ```

--- a/justfile
+++ b/justfile
@@ -260,11 +260,9 @@ bump VERSION:
 
     echo "📦 Bumping ${OLD} → ${NEW}"
 
-    # Update pyproject.toml
+    # Update pyproject.toml (the single source of truth; __version__ is derived
+    # from package metadata at import time, so there is nothing else to bump).
     sed -i '' "s/^version = \"${OLD}\"/version = \"${NEW}\"/" pyproject.toml
-
-    # Update __init__.py
-    sed -i '' "s/__version__ = \"${OLD}\"/__version__ = \"${NEW}\"/" src/graftpunk/__init__.py
 
     # Update CHANGELOG: rename [Unreleased] to [X.Y.Z] with today's date
     DATE=$(date +%Y-%m-%d)
@@ -275,22 +273,22 @@ bump VERSION:
         echo "❌ CHANGELOG.md has no [Unreleased] section."
         echo "   Add your changes under '## [Unreleased]' before bumping."
         echo "   The bump will rename it to '## [${NEW}] - ${DATE}'."
-        # Revert pyproject.toml and __init__.py changes before exiting
-        git checkout -- pyproject.toml src/graftpunk/__init__.py
+        # Revert the pyproject.toml change before exiting
+        git checkout -- pyproject.toml
         exit 1
     fi
 
     # Update lockfile
     uv lock --quiet
-    echo "✅ Updated pyproject.toml, __init__.py, uv.lock"
+    echo "✅ Updated pyproject.toml, uv.lock"
 
     # Create branch, commit, and PR
     BRANCH="chore/bump-v${NEW}"
     git checkout -b "$BRANCH"
-    git add pyproject.toml src/graftpunk/__init__.py uv.lock CHANGELOG.md
+    git add pyproject.toml uv.lock CHANGELOG.md
     git commit -m "chore: bump version to ${NEW}"
     git push -u origin "$BRANCH"
-    gh pr create --title "chore: bump version to ${NEW}" --body "Bump version ${OLD} → ${NEW} (pyproject.toml, __init__.py, uv.lock)"
+    gh pr create --title "chore: bump version to ${NEW}" --body "Bump version ${OLD} → ${NEW} (pyproject.toml, uv.lock)"
 
     echo ""
     echo "✅ PR created for v${NEW}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.9.0"
+version = "1.9.1"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/src/graftpunk/__init__.py
+++ b/src/graftpunk/__init__.py
@@ -20,6 +20,9 @@ Example:
     >>> response = api.get("https://mysite.com/api/data")
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from graftpunk.backends import BrowserBackend, get_backend, list_backends, register_backend
 from graftpunk.cache import (
     cache_session,
@@ -47,7 +50,13 @@ from graftpunk.session import BrowserSession
 from graftpunk.stealth import create_stealth_driver
 from graftpunk.storage.base import SessionMetadata, SessionStorageBackend
 
-__version__ = "1.8.2"
+# Single source of truth: the version lives in pyproject.toml and is read back
+# from the installed package metadata. There is no literal to bump (or forget),
+# so __version__ can never drift from the packaged version.
+try:
+    __version__ = _pkg_version("graftpunk")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.8.2"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Problem

`graftpunk.__version__` drifted from the packaged version. The 1.9.0 release shipped `__version__ == "1.8.2"` even though the package metadata (and `pyproject.toml`) said `1.9.0`.

**Root cause — not a broken guard, a bypassed one.** Every release 1.7.0 → 1.8.2 has a `chore: bump version to X` commit updating `__init__.py` — that's `just bump`'s `sed`. But 1.9.0 was bumped *by hand* (pyproject + CHANGELOG only) during release prep, so the `sed` never ran and the `__init__.py` literal stuck at 1.8.2. Nothing in CI asserts `pyproject == __init__`, so it sailed through. (The same manual bump also left graftpunk's own `uv.lock` self-version at 1.8.2.)

## Fix: make drift unrepresentable

Instead of re-adding automation that can be bypassed again, remove the second source of truth:

```python
from importlib.metadata import PackageNotFoundError, version as _pkg_version
try:
    __version__ = _pkg_version("graftpunk")
except PackageNotFoundError:      # running from a source tree without an install
    __version__ = "0.0.0+unknown"
```

`pyproject.toml` is now the **only** place a version lives; `__version__` is read back from the installed distribution metadata, so it can never disagree — regardless of how a future bump is done.

- Dropped the now-dead `__init__.py` `sed` (+ its `git add` / PR-body mention) from `just bump`.
- Bumped to **1.9.1** and corrected the stale `uv.lock` self-version.
- Rolled the post-1.9.0 `[Unreleased]` CHANGELOG items (Trusted Publishing, `just release` refactor) into the `1.9.1` section.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on `__init__.py`
- [x] `import graftpunk` succeeds; `graftpunk.__version__` resolves from installed metadata (verified: reports the installed dist version, not a literal)
- [x] `uv lock` regenerates with graftpunk self-version `1.9.1`
- [x] Full test suite runs in CI on Python 3.12 (release gate + python-quality)
- [ ] **[post-release]** after 1.9.1 publishes + installs, `python -c "import graftpunk; print(graftpunk.__version__)"` prints `1.9.1`

Cutting **1.9.1** from this (via the normal `just release` tag-push path) also dogfoods the auto-trigger release flow we've so far only exercised via `workflow_dispatch`.