### PR TITLE
fix: mount plugin subcommands under typer>=0.26 (vendored Click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Plugin subcommands stopped mounting under typer>=0.26 (`gp <site>` → "No such command")** — typer 0.26 vendored Click into `typer._click`, so the groups Typer builds (`TyperGroup`) are no longer subclasses of the external `click.Group`. Every `isinstance(x, click.Group)` check in the CLI silently became `False`: `GraftpunkApp` never injected plugin groups (so no `gp <site>` command existed), and nested command groups collided (`command_group_conflict`) instead of being reused, mangling grouped subcommands. Both sites now duck-type the group interface (`.commands` + `.add_command`) via a shared `_is_command_group` helper, which holds for external Click and Typer's fork alike. Affects anyone who installed with typer 0.26+ (the dependency is unpinned).
+
 ## [1.9.1] - 2026-07-17
 
 ### Added

--- a/src/graftpunk/cli/plugin_commands.py
+++ b/src/graftpunk/cli/plugin_commands.py
@@ -58,6 +58,20 @@ def _teardown_all_plugins() -> None:
 atexit.register(_teardown_all_plugins)
 
 
+def _is_command_group(obj: object) -> bool:
+    """True if ``obj`` is a Click/Typer command *group* (can hold subcommands).
+
+    typer>=0.26 vendored Click into ``typer._click``, so ``TyperGroup`` no
+    longer subclasses the external ``click.Group`` — ``isinstance(obj,
+    click.Group)`` is ``False`` for the groups Typer builds (both the app
+    command from ``typer.main.get_command`` and the nested groups we create).
+    Duck-type on the group interface instead (a ``.commands`` mapping plus
+    ``.add_command``), which holds for external Click and Typer's fork alike; a
+    leaf Command has neither, so groups are still distinguished from commands.
+    """
+    return hasattr(obj, "commands") and hasattr(obj, "add_command")
+
+
 class GraftpunkApp(typer.Typer):
     """Extended Typer application with plugin command support.
 
@@ -79,12 +93,22 @@ class GraftpunkApp(typer.Typer):
             raise ValueError(f"Plugin group '{name}' is already registered")
         self._plugin_groups[name] = group
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Build the Click group, inject plugin commands, then run."""
+    def _build_click_app(self) -> Any:
+        """Build the Click command for this app and inject plugin groups.
+
+        Split out from ``__call__`` so the plugin-group injection is unit
+        testable without actually running the CLI (Typer's ``CliRunner`` builds
+        the command itself and would bypass ``__call__`` entirely).
+        """
         click_app = typer.main.get_command(self)
-        if isinstance(click_app, click.Group):
+        if _is_command_group(click_app):
             for name, group in self._plugin_groups.items():
                 click_app.add_command(group, name=name)
+        return click_app
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Build the Click group, inject plugin commands, then run."""
+        click_app = self._build_click_app()
         try:
             return click_app.main(standalone_mode=False)
         except click.UsageError as exc:
@@ -470,7 +494,7 @@ def _ensure_group_hierarchy(parent_group: click.Group, dotted_path: str) -> clic
             )
             current.add_command(new_group, name=part)
             current = new_group
-        elif isinstance(existing, click.Group):
+        elif _is_command_group(existing):
             current = existing
         else:
             # Conflict: a command already exists with this name

--- a/tests/unit/test_plugin_commands.py
+++ b/tests/unit/test_plugin_commands.py
@@ -3318,3 +3318,59 @@ class TestFormatExplicitFlag:
             assert result.exit_code == 0
             mock_fmt.assert_called_once()
             assert mock_fmt.call_args[1]["user_explicit"] is False
+
+
+class TestTyperVendoredClickGroups:
+    """Regression: typer>=0.26 vendored Click into ``typer._click``.
+
+    The groups Typer builds (``TyperGroup``) are no longer subclasses of the
+    external ``click.Group``, so ``isinstance(x, click.Group)`` silently
+    returned False. That skipped plugin-group injection in ``GraftpunkApp``
+    (every ``gp <site>`` became "No such command") and made nested command
+    groups collide instead of being reused.
+    """
+
+    def test_is_command_group_distinguishes_groups_from_commands(self) -> None:
+        import click
+        import typer
+
+        from graftpunk.cli.plugin_commands import _is_command_group
+
+        assert _is_command_group(typer.core.TyperGroup(name="g")) is True
+        assert _is_command_group(click.Group(name="g")) is True
+        assert _is_command_group(click.Command(name="c")) is False
+
+    def test_ensure_group_hierarchy_reuses_existing_typer_group(self) -> None:
+        import click
+        import typer
+
+        from graftpunk.cli.plugin_commands import _ensure_group_hierarchy
+
+        root = typer.core.TyperGroup(name="root")
+        first = _ensure_group_hierarchy(root, "export")
+        second = _ensure_group_hierarchy(root, "export")
+        # Same group reused across calls, not treated as a name conflict.
+        assert first is second
+        first.add_command(click.Command(name="list"), name="list")
+        second.add_command(click.Command(name="get"), name="get")
+        # Both grouped commands land under the single 'export' group.
+        assert set(root.commands["export"].commands) == {"list", "get"}
+
+    def test_app_injects_plugin_groups_despite_vendored_click(self) -> None:
+        import click
+        import typer
+
+        app = GraftpunkApp()
+
+        @app.callback()
+        def _cb() -> None:  # a callback makes Typer build a group, not a command
+            ...
+
+        demo = typer.core.TyperGroup(name="demo")
+        demo.add_command(click.Command(name="ping"), name="ping")
+        app.add_plugin_group("demo", demo)
+
+        click_app = app._build_click_app()
+        # The plugin group is injected and reachable as a subcommand.
+        assert "demo" in click_app.commands
+        assert "ping" in click_app.commands["demo"].commands


### PR DESCRIPTION
## What

`gp <site>` subcommands (e.g. `gp shopkeep login`, `gp shopkeep export list`) stopped mounting — every one reported **"No such command"** — and grouped subcommands got mangled with `command_group_conflict` warnings.

## Root cause

typer **0.26** vendored Click into `typer._click`. The groups Typer builds (`TyperGroup`) are no longer subclasses of the external `click.Group`, so every `isinstance(x, click.Group)` check in `cli/plugin_commands.py` silently became `False`:

- `GraftpunkApp.__call__` guarded plugin-group injection with `isinstance(click_app, click.Group)` → **False** → plugin groups never injected → no `gp <site>` command exists.
- `_ensure_group_hierarchy` guarded group-reuse with `isinstance(existing, click.Group)` → **False** for an existing `TyperGroup` → logged `command_group_conflict` and dropped the grouped command (so `gp shopkeep export` lost `get`/`inventory`/`stock_items`).

The dependency is unpinned (`typer>=0.9.0`), so any fresh install picking up typer 0.26+ is broken. `GraftpunkClient` (library) was unaffected — this is CLI-only.

## Fix

Duck-type the group interface (`.commands` mapping + `.add_command`) via a shared `_is_command_group()` helper instead of `isinstance(..., click.Group)`. It holds for external Click and Typer's vendored fork alike; a leaf `Command` has neither, so groups stay distinguished from commands. Both check sites updated. `GraftpunkApp._build_click_app()` is extracted so the injection is unit-testable (Typer's `CliRunner` bypasses `__call__`).

## Tests

`tests/unit/test_plugin_commands.py::TestTyperVendoredClickGroups`:
- `test_is_command_group_distinguishes_groups_from_commands`
- `test_ensure_group_hierarchy_reuses_existing_typer_group` — **fails pre-fix** (`assert <TyperGroup export> is <TyperGroup root>` — conflict returned root instead of reusing the group)
- `test_app_injects_plugin_groups_despite_vendored_click` — **fails pre-fix** (plugin group never injected)

## Verification

- New tests pass; both fail with the fix reverted (confirmed via stash).
- End-to-end: `gp shopkeep --help` now lists `reorder/export/import/login`; `gp shopkeep export --help` correctly shows `list/get/inventory/stock_items`; `gp shopkeep login` runs the browser login to completion.

## Test plan

- [ ] CI green on 3.11/3.12/3.13 (real no-regression check — local cross-env runs are unreliable)
- [x] New regression tests pass in isolation; fail pre-fix
- [x] `gp shopkeep login` verified end-to-end against the live store (session cached)