### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.11.0] - 2026-07-29
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graftpunk"
-version = "1.10.0"
+version = "1.11.0"
 description = "Turn any website into an API. Graft scriptable access onto authenticated web services."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "graftpunk"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },
@@ -654,13 +654,20 @@ browser = [
     { name = "webdriver-manager" },
 ]
 dev = [
+    { name = "httpie" },
     { name = "mypy" },
+    { name = "nodriver" },
     { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
+    { name = "requestium" },
     { name = "ruff" },
+    { name = "selenium" },
+    { name = "selenium-stealth" },
+    { name = "undetected-chromedriver" },
+    { name = "webdriver-manager" },
 ]
 jmespath = [
     { name = "jmespath" },
@@ -695,6 +702,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "dill", specifier = ">=0.3.0" },
     { name = "fpdf2", specifier = ">=2.8.0" },
+    { name = "graftpunk", extras = ["browser"], marker = "extra == 'dev'" },
     { name = "graftpunk", extras = ["browser"], marker = "extra == 'nodriver'" },
     { name = "graftpunk", extras = ["browser", "supabase", "s3", "jmespath", "nodriver", "dev"], marker = "extra == 'all'" },
     { name = "httpie", marker = "extra == 'browser'", specifier = ">=3.0.0" },


### PR DESCRIPTION
Bump version 1.10.0 → 1.11.0 (pyproject.toml, uv.lock)