### PR TITLE
feat: workstation env file + gp config (lazy credential & settings loading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,25 @@ gp import-har auth-flow.har --name mybank
 
 CLI flags: `-v` (info), `-vv` (debug), `--log-format json`, `--observe full`, `--network-debug` (wire-level HTTP tracing).
 
+### Workstation configuration (`gp config`)
+
+Persist per-machine environment for gp in `~/.config/graftpunk/env` —
+credentials as lazy 1Password (or any) command values, settings as statics:
+
+```bash
+gp config set GRAFTPUNK_BROWSER_EXECUTABLE_PATH "/path/to/chrome"
+gp config set SHOPKEEP_USERNAME '$(op read "op://vault/item/username")'
+gp config set SHOPKEEP_PASSWORD '$(op read "op://vault/item/password")'
+gp config list
+```
+
+Static values load at startup; `$(…)` values run only when a command
+actually needs them (login, or first access of an allowlisted setting) —
+`gp --help` never triggers your secret manager. Real environment variables
+always win over the file. Single-quote command values so your shell doesn't
+evaluate them at `set` time. See `docs/rfcs/2026-07-28-workstation-env.md`
+for the full design.
+
 ## Browser Backends
 
 graftpunk supports two browser automation backends (both included by default):

--- a/README.md
+++ b/README.md
@@ -397,11 +397,13 @@ gp config list
 ```
 
 Static values load at startup; `$(…)` values run only when a command
-actually needs them (login, or first access of an allowlisted setting) —
-`gp --help` never triggers your secret manager. Real environment variables
-always win over the file. Single-quote command values so your shell doesn't
-evaluate them at `set` time. See `docs/rfcs/2026-07-28-workstation-env.md`
-for the full design.
+actually needs them (login, first access of an allowlisted setting, or a
+YAML plugin's `${VAR}` header expansion) — `gp --help` never triggers your
+secret manager. Real environment variables always win over the file — a
+variable set to the empty string counts as unset, so an accidental
+`export FOO=` doesn't shadow a workstation-file value. Single-quote command
+values so your shell doesn't evaluate them at `set` time. See
+`docs/rfcs/2026-07-28-workstation-env.md` for the full design.
 
 ## Browser Backends
 

--- a/docs/rfcs/2026-07-28-workstation-env.md
+++ b/docs/rfcs/2026-07-28-workstation-env.md
@@ -1,0 +1,283 @@
+---
+type: spec
+---
+
+# Workstation environment file + `gp config` (lazy credential & settings loading)
+
+## Problem
+
+graftpunk resolves login credentials from environment variables
+(`{SITE}_{FIELD}`, e.g. `SHOPKEEP_USERNAME`) and its own settings from
+`GRAFTPUNK_*` variables (pydantic-settings, `config.py`). Neither is
+persisted anywhere: every `gp <site> login` requires the operator to have
+exported the right variables in the current shell — in practice
+`export SHOPKEEP_PASSWORD=$(op read "op://…")` retyped per shell, per
+machine-reboot, per session expiry. Settings vars have the same problem:
+on a machine with no system Chrome, forgetting
+`GRAFTPUNK_BROWSER_EXECUTABLE_PATH` fails login with "could not find a
+valid chrome browser binary."
+
+The operator wants a workstation-level file: set the variable → command
+mappings once, and have `gp` load them no matter which shell or directory
+it runs from — **lazily**, so commands like `$(op read …)` (hundreds of
+ms + a possible biometric prompt) run only when a command actually needs
+that variable.
+
+## Requirements
+
+1. **Just work** — no shell profile edits, no aliases, no direnv; works
+   identically from any cwd and in subprocesses that exec `gp`.
+2. **No latency for irrelevant operations** — `gp bek export list` must
+   never pay for `BEK_PASSWORD=$(op read …)`; `gp --help` must never
+   trigger a 1Password biometric prompt.
+3. **Optimize/cache where possible** — never evaluate the same command
+   twice in one process; never persist a resolved secret to disk.
+4. **Convention over configuration** — no new naming scheme: file keys
+   are exactly the env var names graftpunk already consumes.
+5. **CLI-managed** — a `gp config` command family (git-config-shaped)
+   reads, writes, and inspects the file.
+6. **Covers graftpunk settings too** — `GRAFTPUNK_*` vars (e.g.
+   `GRAFTPUNK_BROWSER_EXECUTABLE_PATH`) live in the same file and are
+   visible to pydantic-settings and to child processes.
+
+## Design overview
+
+One file, two-phase loading, three-tier resolution:
+
+```
+~/.config/graftpunk/env          # the workstation env file
+        │
+        ├── PHASE 1 (eager, CLI startup): static values → os.environ
+        │            (only where the real environment doesn't already
+        │             define the variable — real env always wins)
+        │
+        └── PHASE 2 (deferred): $(…) command values are REGISTERED,
+                     not run. They evaluate only at graftpunk's two
+                     env-consumption chokepoints:
+                       a) credential resolution in login_commands.py
+                       b) GraftpunkSettings construction (config.py)
+                     Results are memoized per-process.
+```
+
+Resolution order for a credential field (extends the existing two-tier
+chain in `login_commands.py`; the existing order is unchanged, one tier
+is inserted):
+
+```
+1. real environment variable            (existing)
+2. workstation env file                 (NEW — evaluates $(…) on demand)
+3. interactive prompt                   (existing)
+```
+
+## The file
+
+- **Path:** `<config_dir>/env` where `config_dir` is
+  `GraftpunkSettings.config_dir` (default `~/.config/graftpunk`,
+  overridable via `GRAFTPUNK_CONFIG_DIR`). Note the bootstrap
+  subtlety in "Loading semantics" below.
+- **Format:** line-oriented `NAME=value`.
+  - `NAME` matches `[A-Za-z_][A-Za-z0-9_]*`.
+  - `value` is everything after the first `=`, trimmed of surrounding
+    whitespace; surrounding single or double quotes are stripped if the
+    value is fully quoted. No escape processing beyond that.
+  - A value **containing** `$(` anywhere is a **command value**; it is
+    executed with `/bin/sh -c 'printf %s "<value>"'`-equivalent
+    semantics — concretely, `sh -c 'printf %s ' + value` wrapped so the
+    whole value string (including any literal text around the `$(…)`)
+    undergoes normal shell command substitution. Trailing newline of the
+    result is stripped (matching `$(…)` shell semantics).
+  - Any other value is a **static value**, used verbatim.
+  - `#` at line start (after optional whitespace) is a comment; blank
+    lines allowed. Inline `#` is NOT treated as a comment (values may
+    contain `#`).
+  - Malformed lines (no `=`, bad name): warn once with `file:line`,
+    skip the line, continue.
+- **Permissions:** created `0600`; every CLI write re-asserts `0600`.
+  On read, if the file is group- or world-readable, log a one-line
+  warning (do not refuse — the operator may have reasons).
+- **Example:**
+
+```bash
+# graftpunk workstation environment — managed by `gp config`
+GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/Users/me/Library/Caches/ms-playwright/chromium-1232/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
+
+SHOPKEEP_USERNAME=$(op read "op://grocerbot/lightspeed-backoffice-grocerbot/username")
+SHOPKEEP_PASSWORD=$(op read "op://grocerbot/lightspeed-backoffice-grocerbot/password")
+SHOPKEEP_STORE=the-french-co
+```
+
+## Components
+
+### `src/graftpunk/workstation_env.py` (new)
+
+The single owner of file knowledge. Public surface:
+
+- `load() -> WorkstationEnv` — parse the file (absent file → empty
+  instance), cached per-process (module-level singleton, same pattern as
+  `config.get_settings()`).
+- `WorkstationEnv.inject_static() -> None` — Phase 1: for each static
+  entry whose name is not already in `os.environ`, set it. Called once
+  from CLI startup.
+- `WorkstationEnv.resolve(name: str) -> str | None` — Phase 2: return
+  the memoized result; else if `name` has a command value, execute it
+  (`subprocess.run(["/bin/sh", "-c", …], capture_output=True, text=True)`),
+  memoize, return. Static names return their value (covers callers that
+  consult the file directly before Phase 1 ran, e.g. settings
+  bootstrap). Unknown name → `None`. Command failure (non-zero exit) →
+  log `workstation_env_command_failed` with the var name and the
+  command's stderr, memoize the failure (don't re-run a failing command
+  in the same process), return `None`.
+- `WorkstationEnv.entries() -> list[Entry]` — for `gp config list`;
+  `Entry` carries `name`, `raw_value`, `kind` (`static` | `command`),
+  `line_no`.
+- Writer functions used by the CLI: `set_entry(name, value)`,
+  `unset_entry(name)` — **surgical line edits**: replace the existing
+  `NAME=` line in place, append new names at end of file; never
+  reserialize, so comments, blank lines, and ordering survive. Writes
+  go to a temp file in the same directory + `os.replace` (atomic), then
+  `chmod 0600`.
+
+No imports from `graftpunk.config` at module import time except for the
+config-dir path helper (see bootstrap note) — keep this module import-light
+so CLI startup stays fast.
+
+### Phase 1 hook — CLI startup (`cli/main.py`)
+
+At the top of `main_callback()` (the root Typer callback,
+`cli/main.py:79`, which runs before any subcommand): call
+`workstation_env.load().inject_static()`. Cost is one small-file parse.
+This makes static values (browser path, store name) visible to
+pydantic-settings, plugins, and child processes for the entire
+invocation.
+
+### Phase 2 hook (a) — credential resolution (`cli/login_commands.py`)
+
+In `_build_login_body()`'s `body()` (the `for field_name in fields:`
+loop, currently env-hit → else prompt): insert the file tier:
+
+```python
+env_value = os.environ.get(envvar)
+if not env_value:
+    env_value = workstation_env.load().resolve(envvar)   # NEW
+if env_value:
+    credentials[field_name] = env_value
+else:
+    credentials[field_name] = typer.prompt(…)            # unchanged
+```
+
+`resolve()` runs `$(op read …)` here — the only moment a credential
+command executes. A failed command logs and falls through to the prompt,
+so login degrades to exactly today's behavior.
+
+### Phase 2 hook (b) — settings construction (`config.py`)
+
+`GraftpunkSettings` is a per-process singleton built on first
+`get_settings()` call. Because Phase 1 has already injected static
+`GRAFTPUNK_*` values into `os.environ` before any subcommand runs,
+pydantic-settings sees them with **no changes to `config.py`'s field
+machinery**. For *command-valued* `GRAFTPUNK_*` entries, `get_settings()`
+gains one pre-step: before constructing `GraftpunkSettings`, iterate the
+file's command entries whose names start with `GRAFTPUNK_` and are not
+already in `os.environ`; `resolve()` each and put the result in
+`os.environ`. This runs once per process, only for command entries the
+operator chose to make commands.
+
+**Documented convention (not enforced):** settings values should be
+static; commands are for credentials. A command-valued `GRAFTPUNK_*` var
+costs its evaluation on first settings touch in every `gp` process — the
+operator opted in by writing it.
+
+**Bootstrap subtlety:** the file path comes from
+`settings.config_dir`, but settings construction may now consult the
+file — a cycle. Break it by computing the file path *without*
+`get_settings()`: read `GRAFTPUNK_CONFIG_DIR` from the real environment
+directly, defaulting to `~/.config/graftpunk` (mirroring the field
+default). A `GRAFTPUNK_CONFIG_DIR` entry *inside* the workstation env
+file is explicitly unsupported (documented; the file cannot relocate
+itself).
+
+### `gp config` command family (`cli/config_commands.py`, new)
+
+A `typer.Typer` sub-app attached in `main.py` alongside the existing
+`session_app` / `http_app` (`app.add_typer(config_app)`):
+
+| Command | Behavior |
+|---|---|
+| `gp config path` | Print the file's absolute path (whether or not it exists). |
+| `gp config list` | Print `NAME=raw_value` per entry, file order. Commands display unevaluated. Nothing is masked — the convention keeps secrets behind `$(…)`, which is safe to show. Absent/empty file → no output, exit 0. |
+| `gp config get NAME` | Print the raw stored value. Exit 1, message on stderr, if unset. |
+| `gp config get NAME --resolve` | Evaluate a command value and print the result (explicit opt-in to printing a secret, same posture as `op read`). Static values print verbatim. Failed command → its stderr and exit 1. |
+| `gp config set NAME VALUE` | Validate `NAME` against `[A-Za-z_][A-Za-z0-9_]*`; write/replace surgically; create file (0600) and parent dir if needed. `VALUE` stored verbatim — the operator's shell quoting (`'$(op read …)'`) is what defers evaluation. |
+| `gp config unset NAME` | Remove the entry. Exit 0 even if absent (idempotent). |
+| `gp config edit` | Open the file in `$EDITOR` (fall back to `$VISUAL`, then `vi`); create the file first if absent. |
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| File absent | All tiers act as empty; zero output, zero cost beyond one `stat`. |
+| Malformed line | One warning (`file:line`), line skipped. |
+| Command fails at credential time | Error log with var name + command stderr → fall through to interactive prompt. |
+| Command fails at settings time | Same log → pydantic's normal missing-field behavior. |
+| Duplicate `NAME` lines | Last one wins (shell semantics); `gp config set` replaces the last occurrence and warns about the duplicates. |
+| File not writable on `set`/`unset` | Clear error, exit 1. |
+| World/group-readable file | One-line warning on load. |
+
+## Security posture
+
+- Resolved secrets exist only in process memory (and in `os.environ` of
+  the running `gp` process and its children — which is exactly where the
+  operator previously exported them by hand).
+- Nothing resolved is ever written to disk; the memo cache is
+  per-process.
+- The file itself contains commands and non-secret literals; it is
+  `0600` anyway because command strings reveal vault structure and
+  because someone will eventually put a literal secret in it.
+- Command values are arbitrary code execution **by design** (the file is
+  operator-owned config, same trust class as `~/.zshrc`). `gp config
+  set` does not evaluate anything.
+
+## Non-goals
+
+- No secret-manager integration beyond "run a command" (op, vault CLI,
+  pass, anything — they're all just commands).
+- No cross-process caching of resolved secrets (1Password's own session
+  unlock already amortizes biometric prompts).
+- No per-site file sharding — laziness is per-variable, so one file
+  costs nothing extra.
+- No enforcement that settings values are static (documented convention
+  only).
+- No Windows support beyond what `/bin/sh` availability implies (matches
+  the project's current posture).
+- Does not fix Python-3.14 nodriver importability; that constraint is
+  orthogonal (login must still run from a venv whose nodriver imports).
+
+## Testing
+
+`tests/unit/test_workstation_env.py` (new) + additions to CLI tests:
+
+1. **Parser:** comments/blank lines preserved conceptually (entries carry
+   line numbers); quoted values unquoted; inline `#` kept; malformed
+   lines warn and skip; duplicate names → last wins.
+2. **Writer round-trip:** `set` on a file with comments preserves every
+   non-target line byte-for-byte; `set` of a new name appends; `unset`
+   removes exactly one line; file mode is 0600 after every write; write
+   is atomic (temp + replace).
+3. **Phase 1:** statics land in `os.environ`; a real env var is never
+   overwritten; command values are **not** in `os.environ` after
+   startup.
+4. **Laziness regression (load-bearing):** with a command entry present,
+   running a non-login CLI command executes **zero** subprocesses from
+   this module (spy on `subprocess.run`).
+5. **Phase 2a:** credential resolution order — real env beats file;
+   file beats prompt; command evaluated exactly once per process
+   (memoized); failing command → warning + prompt fallback.
+6. **Phase 2b:** command-valued `GRAFTPUNK_*` entry resolves at first
+   `get_settings()`; static `GRAFTPUNK_*` visible via Phase 1 with no
+   settings-code involvement.
+7. **CLI:** every verb via typer's `CliRunner` — `get` (hit, miss,
+   `--resolve` static, `--resolve` command via mocked subprocess), `set`
+   (new, replace, bad name), `unset` (present, absent), `list`, `path`,
+   `edit` (`$EDITOR` invocation mocked).
+8. **Bootstrap:** file path honors real-env `GRAFTPUNK_CONFIG_DIR`
+   without constructing settings.

--- a/docs/rfcs/2026-07-28-workstation-env.md
+++ b/docs/rfcs/2026-07-28-workstation-env.md
@@ -6,22 +6,23 @@ type: spec
 
 ## Problem
 
-graftpunk resolves login credentials from environment variables
-(`{SITE}_{FIELD}`, e.g. `SHOPKEEP_USERNAME`) and its own settings from
-`GRAFTPUNK_*` variables (pydantic-settings, `config.py`). Neither is
-persisted anywhere: every `gp <site> login` requires the operator to have
-exported the right variables in the current shell — in practice
-`export SHOPKEEP_PASSWORD=$(op read "op://…")` retyped per shell, per
-machine-reboot, per session expiry. Settings vars have the same problem:
-on a machine with no system Chrome, forgetting
+graftpunk resolves login credentials from environment variables — the
+derived `{SITE}_{FIELD}` names (e.g. `SHOPKEEP_USERNAME`), or per-plugin
+`username_envvar`/`password_envvar` overrides (`cli/login_commands.py:108-123`)
+— and its own settings from `GRAFTPUNK_*` variables (pydantic-settings,
+`config.py`). Credentials are not persisted anywhere; settings can only be
+persisted in a **cwd-relative** `.env` file (pydantic-settings
+`env_file=".env"`, `config.py:94`), which fails "works from any cwd." In
+practice `export SHOPKEEP_PASSWORD=$(op read "op://…")` is retyped per
+shell, and on a machine with no system Chrome, forgetting
 `GRAFTPUNK_BROWSER_EXECUTABLE_PATH` fails login with "could not find a
 valid chrome browser binary."
 
 The operator wants a workstation-level file: set the variable → command
 mappings once, and have `gp` load them no matter which shell or directory
 it runs from — **lazily**, so commands like `$(op read …)` (hundreds of
-ms + a possible biometric prompt) run only when a command actually needs
-that variable.
+ms + a possible biometric prompt) run only when something actually
+consumes that variable.
 
 ## Requirements
 
@@ -29,7 +30,8 @@ that variable.
    identically from any cwd and in subprocesses that exec `gp`.
 2. **No latency for irrelevant operations** — `gp bek export list` must
    never pay for `BEK_PASSWORD=$(op read …)`; `gp --help` must never
-   trigger a 1Password biometric prompt.
+   trigger a 1Password biometric prompt, even when command-valued
+   `GRAFTPUNK_*` entries exist.
 3. **Optimize/cache where possible** — never evaluate the same command
    twice in one process; never persist a resolved secret to disk.
 4. **Convention over configuration** — no new naming scheme: file keys
@@ -37,64 +39,101 @@ that variable.
 5. **CLI-managed** — a `gp config` command family (git-config-shaped)
    reads, writes, and inspects the file.
 6. **Covers graftpunk settings too** — `GRAFTPUNK_*` vars (e.g.
-   `GRAFTPUNK_BROWSER_EXECUTABLE_PATH`) live in the same file and are
-   visible to pydantic-settings and to child processes.
+   `GRAFTPUNK_BROWSER_EXECUTABLE_PATH`) live in the same file, are
+   visible to pydantic-settings and child processes, and may themselves
+   be command-valued without violating requirement 2.
+
+## The laziness contract (design principle)
+
+Laziness is **access-driven**: a command value evaluates at the moment
+some code first asks for that variable, and never before. It is the
+responsibility of graftpunk core and plugin authors to **place access
+intentionally** — read credentials through the login resolution chain,
+read settings inside command bodies via `get_settings().<field>`, and
+never read lazily-resolvable variables at module import time. The design
+does not defensively engineer around careless early access; instead it
+documents exactly which variables early access makes static-only (see
+"Known import-time accesses" below).
 
 ## Design overview
 
-One file, two-phase loading, three-tier resolution:
+One file, two loading mechanisms, one precedence rule:
 
 ```
 ~/.config/graftpunk/env          # the workstation env file
         │
-        ├── PHASE 1 (eager, CLI startup): static values → os.environ
-        │            (only where the real environment doesn't already
-        │             define the variable — real env always wins)
+        ├── STATIC values: injected into os.environ at process bootstrap
+        │     (module scope of cli/main.py, BEFORE logging config and
+        │      plugin registration), only where the real environment
+        │      doesn't already define the name — real env always wins.
         │
-        └── PHASE 2 (deferred): $(…) command values are REGISTERED,
-                     not run. They evaluate only at graftpunk's two
-                     env-consumption chokepoints:
-                       a) credential resolution in login_commands.py
-                       b) GraftpunkSettings construction (config.py)
-                     Results are memoized per-process.
+        └── COMMAND values ($(…)): registered, never run at bootstrap.
+              They evaluate on first access, at three instrumented
+              consumption points:
+                a) credential resolution   (cli/login_commands.py)
+                b) settings field access   (lazy proxy over GraftpunkSettings)
+                c) YAML plugin ${VAR} header expansion (plugins/yaml_loader.py)
+              Results (and failures) are memoized per-process.
 ```
 
-Resolution order for a credential field (extends the existing two-tier
-chain in `login_commands.py`; the existing order is unchanged, one tier
-is inserted):
+Precedence, owned by a single lookup function (see Components):
 
-```
-1. real environment variable            (existing)
-2. workstation env file                 (NEW — evaluates $(…) on demand)
-3. interactive prompt                   (existing)
-```
+- **Credentials:** real env → workstation file → interactive prompt.
+- **Settings (`GRAFTPUNK_*`):** real env → workstation file → cwd `.env`
+  (pydantic's existing `env_file` source) → field default. The
+  workstation file outranks cwd `.env` because statics are injected into
+  `os.environ` and pydantic ranks env above dotenv — this is intended
+  and documented: the workstation file is the machine-global answer, the
+  cwd `.env` remains a per-project override *only* for values the
+  workstation file doesn't set.
+- **YAML plugin headers:** real env → workstation file → existing
+  `PluginError` ("Environment variable $X is not set").
+
+Other env reads exist and are **not** instrumented — by the laziness
+contract they work with static values (via bootstrap injection) but not
+command values. Known import-time accesses (static-only, documented):
+`GRAFTPUNK_LOG_LEVEL` / `GRAFTPUNK_LOG_FORMAT` (`cli/main.py`, read at
+module scope for early logging — bootstrap injection precedes them, so
+file *statics* do work), `GRAFTPUNK_SESSION` (`session_context.py:27`),
+`GP_DOWNLOADS_DIR` (`plugins/export.py:35`), and `settings.plugins_dir`
+(accessed during import-time plugin discovery — a command value there
+would evaluate at import; keep it static).
 
 ## The file
 
-- **Path:** `<config_dir>/env` where `config_dir` is
-  `GraftpunkSettings.config_dir` (default `~/.config/graftpunk`,
-  overridable via `GRAFTPUNK_CONFIG_DIR`). Note the bootstrap
-  subtlety in "Loading semantics" below.
+- **Path:** `<config_dir>/env` where `<config_dir>` comes from the shared
+  settings-free resolver `graftpunk.paths.config_dir()` (see Components):
+  `GRAFTPUNK_CONFIG_DIR` from the **real environment**, else
+  `~/.config/graftpunk`. A `GRAFTPUNK_CONFIG_DIR` set only in a cwd
+  `.env` moves `settings.config_dir` (pydantic still honors it) but does
+  NOT move the workstation env file — documented as unsupported; don't
+  do that. An entry for `GRAFTPUNK_CONFIG_DIR` *inside* the file is
+  likewise unsupported (the file cannot relocate itself).
 - **Format:** line-oriented `NAME=value`.
   - `NAME` matches `[A-Za-z_][A-Za-z0-9_]*`.
   - `value` is everything after the first `=`, trimmed of surrounding
-    whitespace; surrounding single or double quotes are stripped if the
-    value is fully quoted. No escape processing beyond that.
-  - A value **containing** `$(` anywhere is a **command value**; it is
-    executed with `/bin/sh -c 'printf %s "<value>"'`-equivalent
-    semantics — concretely, `sh -c 'printf %s ' + value` wrapped so the
-    whole value string (including any literal text around the `$(…)`)
-    undergoes normal shell command substitution. Trailing newline of the
-    result is stripped (matching `$(…)` shell semantics).
+    whitespace. Quote handling runs **first**: if the value is fully
+    single-quoted, the quotes are stripped and the value is **always
+    static** — the escape hatch for a literal `$(`. If fully
+    double-quoted, the quotes are stripped and command detection
+    proceeds. No other escape processing.
+  - After quote handling, a value is a **command value** iff the entire
+    value is one command substitution: it matches `^\$\(.*\)$`. The
+    inner text (between `$(` and the final `)`) is executed via
+    `subprocess.run(["/bin/sh", "-c", inner], capture_output=True,
+    text=True)`; stdout with exactly one trailing newline stripped is
+    the result (matching `$(…)` shell semantics). Values that merely
+    *contain* `$(` mixed with literal text are unsupported: treated as
+    static, with a one-time warning naming the line.
   - Any other value is a **static value**, used verbatim.
   - `#` at line start (after optional whitespace) is a comment; blank
-    lines allowed. Inline `#` is NOT treated as a comment (values may
-    contain `#`).
+    lines allowed. Inline `#` is NOT a comment (values may contain `#`).
   - Malformed lines (no `=`, bad name): warn once with `file:line`,
     skip the line, continue.
+  - Duplicate `NAME` lines: last one wins (shell semantics).
 - **Permissions:** created `0600`; every CLI write re-asserts `0600`.
   On read, if the file is group- or world-readable, log a one-line
-  warning (do not refuse — the operator may have reasons).
+  warning (do not refuse).
 - **Example:**
 
 ```bash
@@ -103,113 +142,178 @@ GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/Users/me/Library/Caches/ms-playwright/chromiu
 
 SHOPKEEP_USERNAME=$(op read "op://grocerbot/lightspeed-backoffice-grocerbot/username")
 SHOPKEEP_PASSWORD=$(op read "op://grocerbot/lightspeed-backoffice-grocerbot/password")
-SHOPKEEP_STORE=the-french-co
+SHOPKEEP_STORE_NAME=the-french-co
 ```
+
+File keys for login fields must match the **derived** env var names —
+`{SITE}_{FIELD}` (so shopkeep's `store_name` field is
+`SHOPKEEP_STORE_NAME`), or, for plugins that define
+`username_envvar`/`password_envvar`, those override names. The design
+handles overrides automatically because resolution is keyed on the final
+computed envvar.
 
 ## Components
 
+### `src/graftpunk/paths.py` (new, tiny)
+
+The single owner of "where is the config dir," shared by pydantic and
+the workstation-env module so the two can never diverge:
+
+- `config_dir() -> Path` — `GRAFTPUNK_CONFIG_DIR` from the real
+  environment, else `~/.config/graftpunk`. **Settings-free and
+  side-effect-free**: no `get_settings()`, no directory creation
+  (`GraftpunkSettings.__init__` creates directories, `config.py:99-106`
+  — this helper must not).
+- `workstation_env_path() -> Path` — `config_dir() / "env"`.
+- `GraftpunkSettings.config_dir`'s field default becomes
+  `default_factory=paths.config_dir` (pydantic env sources still
+  override it as today).
+
 ### `src/graftpunk/workstation_env.py` (new)
 
-The single owner of file knowledge. Public surface:
+The single owner of file knowledge **and** of the env-beats-file
+precedence rule. Import-light (imports `paths`, never `config`).
 
 - `load() -> WorkstationEnv` — parse the file (absent file → empty
-  instance), cached per-process (module-level singleton, same pattern as
-  `config.get_settings()`).
-- `WorkstationEnv.inject_static() -> None` — Phase 1: for each static
-  entry whose name is not already in `os.environ`, set it. Called once
-  from CLI startup.
-- `WorkstationEnv.resolve(name: str) -> str | None` — Phase 2: return
-  the memoized result; else if `name` has a command value, execute it
-  (`subprocess.run(["/bin/sh", "-c", …], capture_output=True, text=True)`),
-  memoize, return. Static names return their value (covers callers that
-  consult the file directly before Phase 1 ran, e.g. settings
-  bootstrap). Unknown name → `None`. Command failure (non-zero exit) →
-  log `workstation_env_command_failed` with the var name and the
-  command's stderr, memoize the failure (don't re-run a failing command
-  in the same process), return `None`.
+  instance), cached per-process.
+- `WorkstationEnv.inject_static() -> None` — bootstrap: for each static
+  entry whose name is not already in `os.environ`, set it.
+- `WorkstationEnv.lookup(name: str) -> str | None` — **the public
+  resolution entry point; the only implementation of the precedence
+  rule.** Order: `os.environ` (hit → return it, including values
+  injected at bootstrap) → file entry (static → its value; command →
+  memoized result, else execute now, memoize, return) → `None`.
+  Command failure (non-zero exit): log
+  `workstation_env_command_failed` with the var name and the command's
+  stderr, memoize the failure (never re-run a failing command in the
+  same process), return `None`.
+- `WorkstationEnv.command_entry_names() -> set[str]` — names of
+  command-valued entries (the lazy-settings proxy consults this).
 - `WorkstationEnv.entries() -> list[Entry]` — for `gp config list`;
   `Entry` carries `name`, `raw_value`, `kind` (`static` | `command`),
   `line_no`.
 - Writer functions used by the CLI: `set_entry(name, value)`,
-  `unset_entry(name)` — **surgical line edits**: replace the existing
-  `NAME=` line in place, append new names at end of file; never
-  reserialize, so comments, blank lines, and ordering survive. Writes
-  go to a temp file in the same directory + `os.replace` (atomic), then
-  `chmod 0600`.
+  `unset_entry(name)`. Surgical line edits — replace the existing
+  `NAME=` line in place (last occurrence when duplicated, with a
+  warning listing the others), append new names at end of file; never
+  reserialize, so comments, blank lines, and ordering survive.
+  `unset_entry` removes **all** occurrences of `NAME` (git-config
+  `--unset-all` semantics; duplicates are never intentional), warning
+  when more than one line was removed. Writes go to a temp file in the
+  same directory + `os.replace` (atomic), then `chmod 0600`.
 
-No imports from `graftpunk.config` at module import time except for the
-config-dir path helper (see bootstrap note) — keep this module import-light
-so CLI startup stays fast.
+Callers never sequence "check os.environ, then the file" by hand —
+that inversion-prone duplication is what `lookup()` exists to prevent.
 
-### Phase 1 hook — CLI startup (`cli/main.py`)
+### Bootstrap hook — module scope of `cli/main.py`
 
-At the top of `main_callback()` (the root Typer callback,
-`cli/main.py:79`, which runs before any subcommand): call
-`workstation_env.load().inject_static()`. Cost is one small-file parse.
-This makes static values (browser path, store name) visible to
-pydantic-settings, plugins, and child processes for the entire
-invocation.
-
-### Phase 2 hook (a) — credential resolution (`cli/login_commands.py`)
-
-In `_build_login_body()`'s `body()` (the `for field_name in fields:`
-loop, currently env-hit → else prompt): insert the file tier:
+Immediately after imports, **before** the module-level
+`configure_logging` call (currently `cli/main.py:41-44`) and before
+`register_plugin_commands(app)` (currently `cli/main.py:810-812`):
 
 ```python
-env_value = os.environ.get(envvar)
-if not env_value:
-    env_value = workstation_env.load().resolve(envvar)   # NEW
+from graftpunk import workstation_env
+workstation_env.load().inject_static()
+```
+
+This ordering is the design's load-bearing invariant, so it is owned
+structurally, not positionally: a lifecycle-faithful test (Testing #1)
+imports the real CLI module fresh and asserts injected statics are
+visible in `get_settings()` — any future re-ordering that constructs
+settings before injection fails that test. Because injection precedes
+the early logging config, file *statics* for
+`GRAFTPUNK_LOG_LEVEL`/`GRAFTPUNK_LOG_FORMAT` take effect too.
+
+Rationale for module scope rather than `main_callback()`: the settings
+singleton is constructed at import time — `register_plugin_commands`
+drives plugin discovery, which calls `get_settings()`
+(`plugins/yaml_loader.py:452`, `plugins/python_loader.py:127`) — so any
+hook inside a Typer callback runs after the singleton is frozen.
+
+### Consumption point (a) — credential resolution (`cli/login_commands.py`)
+
+In `make_login_body()`'s `body()` (the `for field_name in fields:` loop,
+`cli/login_commands.py:121-134`), the env lookup is replaced by the
+single precedence-owning entry point:
+
+```python
+env_value = workstation_env.load().lookup(envvar)   # env → file
 if env_value:
     credentials[field_name] = env_value
 else:
-    credentials[field_name] = typer.prompt(…)            # unchanged
+    credentials[field_name] = typer.prompt(…)        # unchanged
 ```
 
-`resolve()` runs `$(op read …)` here — the only moment a credential
-command executes. A failed command logs and falls through to the prompt,
-so login degrades to exactly today's behavior.
+`lookup()` runs `$(op read …)` here — for credentials, the only moment
+a command executes. A failed command logs and falls through to the
+prompt, so login degrades to exactly today's behavior. Note one
+deliberate behavior change: an env var set to the **empty string**
+previously logged `login_envvar_empty` and prompted; it now falls
+through to the file tier first, then the prompt — intended.
 
-### Phase 2 hook (b) — settings construction (`config.py`)
+### Consumption point (b) — lazy settings field access (`config.py`)
 
-`GraftpunkSettings` is a per-process singleton built on first
-`get_settings()` call. Because Phase 1 has already injected static
-`GRAFTPUNK_*` values into `os.environ` before any subcommand runs,
-pydantic-settings sees them with **no changes to `config.py`'s field
-machinery**. For *command-valued* `GRAFTPUNK_*` entries, `get_settings()`
-gains one pre-step: before constructing `GraftpunkSettings`, iterate the
-file's command entries whose names start with `GRAFTPUNK_` and are not
-already in `os.environ`; `resolve()` each and put the result in
-`os.environ`. This runs once per process, only for command entries the
-operator chose to make commands.
+`get_settings()` keeps constructing the `GraftpunkSettings` singleton
+exactly as today (pydantic reads real env, injected statics, and cwd
+`.env` at construction). What changes is the return value when — and
+only when — the workstation file contains command-valued `GRAFTPUNK_*`
+entries for fields pydantic did not receive from any source
+(`model_fields_set`): `get_settings()` wraps the singleton in a
+`LazySettings` proxy (~50 lines, defined in `config.py`):
 
-**Documented convention (not enforced):** settings values should be
-static; commands are for credentials. A command-valued `GRAFTPUNK_*` var
-costs its evaluation on first settings touch in every `gp` process — the
-operator opted in by writing it.
+- `__getattr__(field)`: if `field` is in the lazy overlay (command
+  entry `GRAFTPUNK_<FIELD>` exists, field not provided by env/.env,
+  not yet resolved) → `workstation_env.load().lookup(...)`, coerce via
+  the field's pydantic `TypeAdapter`, cache on the proxy, return.
+  Otherwise delegate to the underlying model. Failed command → the
+  field's pydantic default (no `GraftpunkSettings` field is required,
+  so there is no missing-field error path; a bad value surfaces
+  downstream, e.g. `get_storage_config()`'s `ValueError` or a
+  browser-not-found failure).
+- When the file has no command-valued `GRAFTPUNK_*` entries (the common
+  case), `get_settings()` returns the raw model — zero overhead, zero
+  behavior change.
 
-**Bootstrap subtlety:** the file path comes from
-`settings.config_dir`, but settings construction may now consult the
-file — a cycle. Break it by computing the file path *without*
-`get_settings()`: read `GRAFTPUNK_CONFIG_DIR` from the real environment
-directly, defaulting to `~/.config/graftpunk` (mirroring the field
-default). A `GRAFTPUNK_CONFIG_DIR` entry *inside* the workstation env
-file is explicitly unsupported (documented; the file cannot relocate
-itself).
+Consequences, per the laziness contract: `gp --help` constructs the
+proxy but accesses no lazy field → zero evaluations. A command-valued
+`GRAFTPUNK_BROWSER_EXECUTABLE_PATH` evaluates when session start first
+reads it (`session.py:130`) — inside a login, exactly where the cost
+belongs. A command-valued `plugins_dir` would evaluate at import
+(discovery accesses it); the contract says keep such fields static.
+
+### Consumption point (c) — YAML plugin header expansion
+
+`expand_env_vars` (`plugins/yaml_loader.py:124-146`), invoked at
+command-execution time from `plugins/yaml_plugin.py:126-128`, currently
+raises `PluginError` when `os.environ` lacks `${VAR}`. It gains a
+one-line fallback: on miss, consult `workstation_env.load().lookup(var)`
+before raising. This makes API-key-style headers first-class lazy
+consumers — the evaluation happens when that plugin command actually
+runs.
 
 ### `gp config` command family (`cli/config_commands.py`, new)
 
-A `typer.Typer` sub-app attached in `main.py` alongside the existing
-`session_app` / `http_app` (`app.add_typer(config_app)`):
+**Namespace migration:** `gp config` already exists as a plain command —
+`@app.command("config")` at `cli/main.py:784-803`, a settings display
+panel advertised in the root help text (`cli/main.py:61`). That command
+is **removed** and its behavior absorbed: `config_app` is a
+`typer.Typer(invoke_without_command=True)` whose callback, when invoked
+with no subcommand, renders the same settings display — so bare
+`gp config` keeps its current behavior verbatim, and the display is also
+available explicitly as `gp config show`. The root help text is updated
+in the same change.
 
 | Command | Behavior |
 |---|---|
-| `gp config path` | Print the file's absolute path (whether or not it exists). |
-| `gp config list` | Print `NAME=raw_value` per entry, file order. Commands display unevaluated. Nothing is masked — the convention keeps secrets behind `$(…)`, which is safe to show. Absent/empty file → no output, exit 0. |
+| `gp config` | (no subcommand) Current settings display — unchanged behavior, migrated home. |
+| `gp config show` | Same display, explicit verb. |
+| `gp config path` | Print the workstation env file's absolute path (whether or not it exists). |
+| `gp config list` | Print `NAME=raw_value` per entry, file order. Commands display unevaluated. Nothing is masked — the convention keeps secrets behind `$(…)`; a literal secret stored against convention IS printed, an acknowledged residual exposure consistent with the 0600 posture. Absent/empty file → no output, exit 0. |
 | `gp config get NAME` | Print the raw stored value. Exit 1, message on stderr, if unset. |
 | `gp config get NAME --resolve` | Evaluate a command value and print the result (explicit opt-in to printing a secret, same posture as `op read`). Static values print verbatim. Failed command → its stderr and exit 1. |
-| `gp config set NAME VALUE` | Validate `NAME` against `[A-Za-z_][A-Za-z0-9_]*`; write/replace surgically; create file (0600) and parent dir if needed. `VALUE` stored verbatim — the operator's shell quoting (`'$(op read …)'`) is what defers evaluation. |
-| `gp config unset NAME` | Remove the entry. Exit 0 even if absent (idempotent). |
-| `gp config edit` | Open the file in `$EDITOR` (fall back to `$VISUAL`, then `vi`); create the file first if absent. |
+| `gp config set NAME VALUE` | Validate `NAME` against `[A-Za-z_][A-Za-z0-9_]*`; write/replace surgically; create file (0600) and parent dir if needed. `VALUE` stored verbatim — the operator's shell quoting (`'$(op read …)'`) is what defers evaluation. **Guardrail:** when `NAME` contains a secret keyword (`password`/`secret`/`token`/`key`, matching `login_commands.py:106`) and `VALUE` contains no `$(`, warn: the operator's shell may have already substituted an unquoted `$(op read …)`, and a plaintext secret is being written to disk. Warn, don't refuse. |
+| `gp config unset NAME` | Remove **all** occurrences (see writer semantics). Exit 0 even if absent (idempotent). |
+| `gp config edit` | Open the file in `$VISUAL`, else `$EDITOR`, else `vi`; create the file first if absent. |
 
 ## Error handling summary
 
@@ -217,22 +321,28 @@ A `typer.Typer` sub-app attached in `main.py` alongside the existing
 |---|---|
 | File absent | All tiers act as empty; zero output, zero cost beyond one `stat`. |
 | Malformed line | One warning (`file:line`), line skipped. |
+| Mixed literal+`$(…)` value | Treated as static; one-time warning naming the line. |
 | Command fails at credential time | Error log with var name + command stderr → fall through to interactive prompt. |
-| Command fails at settings time | Same log → pydantic's normal missing-field behavior. |
-| Duplicate `NAME` lines | Last one wins (shell semantics); `gp config set` replaces the last occurrence and warns about the duplicates. |
+| Command fails at settings access | Same log → field keeps its pydantic default (no required fields exist); surfaces downstream if it matters. |
+| Command fails at YAML header expansion | Same log → existing `PluginError` ("Environment variable $X is not set"). |
+| Duplicate `NAME` lines | Read: last wins. `set`: replaces last, warns about the others. `unset`: removes all, warns if >1. |
 | File not writable on `set`/`unset` | Clear error, exit 1. |
 | World/group-readable file | One-line warning on load. |
 
 ## Security posture
 
 - Resolved secrets exist only in process memory (and in `os.environ` of
-  the running `gp` process and its children — which is exactly where the
-  operator previously exported them by hand).
+  the running `gp` process and its children for statics — exactly where
+  the operator previously exported them by hand). Lazily-resolved
+  command results are held on the proxy/memo, not exported to
+  `os.environ`.
 - Nothing resolved is ever written to disk; the memo cache is
   per-process.
-- The file itself contains commands and non-secret literals; it is
-  `0600` anyway because command strings reveal vault structure and
-  because someone will eventually put a literal secret in it.
+- The file is `0600` because command strings reveal vault structure and
+  because someone will eventually put a literal secret in it — `gp
+  config set`'s guardrail warns at the moment that's about to happen,
+  and `list`/`get` printing raw values is the acknowledged residual
+  exposure of that failure mode.
 - Command values are arbitrary code execution **by design** (the file is
   operator-owned config, same trust class as `~/.zshrc`). `gp config
   set` does not evaluate anything.
@@ -240,44 +350,66 @@ A `typer.Typer` sub-app attached in `main.py` alongside the existing
 ## Non-goals
 
 - No secret-manager integration beyond "run a command" (op, vault CLI,
-  pass, anything — they're all just commands).
+  pass — they're all just commands).
 - No cross-process caching of resolved secrets (1Password's own session
   unlock already amortizes biometric prompts).
-- No per-site file sharding — laziness is per-variable, so one file
-  costs nothing extra.
-- No enforcement that settings values are static (documented convention
-  only).
-- No Windows support beyond what `/bin/sh` availability implies (matches
-  the project's current posture).
-- Does not fix Python-3.14 nodriver importability; that constraint is
-  orthogonal (login must still run from a venv whose nodriver imports).
+- No per-site file sharding — laziness is per-variable.
+- No instrumentation of every env read in the codebase — the laziness
+  contract governs; un-instrumented reads get statics only.
+- No `.env` deprecation: pydantic's cwd `.env` source stays, one rung
+  below the workstation file in the documented precedence.
+- No Windows support beyond what `/bin/sh` availability implies.
+- Does not fix Python-3.14 nodriver importability; orthogonal.
 
 ## Testing
 
-`tests/unit/test_workstation_env.py` (new) + additions to CLI tests:
+`tests/unit/test_workstation_env.py`, `tests/unit/test_paths.py`,
+additions to CLI tests. Items 1–2 are the load-bearing,
+**lifecycle-faithful** tests: they drive the real entry path (fresh
+import of `graftpunk.cli.main` with a scrubbed `sys.modules` and
+`reset_settings()`, tmp `GRAFTPUNK_CONFIG_DIR`, typer `CliRunner`), not
+phases called in an assumed order.
 
-1. **Parser:** comments/blank lines preserved conceptually (entries carry
-   line numbers); quoted values unquoted; inline `#` kept; malformed
-   lines warn and skip; duplicate names → last wins.
-2. **Writer round-trip:** `set` on a file with comments preserves every
-   non-target line byte-for-byte; `set` of a new name appends; `unset`
-   removes exactly one line; file mode is 0600 after every write; write
-   is atomic (temp + replace).
-3. **Phase 1:** statics land in `os.environ`; a real env var is never
-   overwritten; command values are **not** in `os.environ` after
-   startup.
-4. **Laziness regression (load-bearing):** with a command entry present,
-   running a non-login CLI command executes **zero** subprocesses from
-   this module (spy on `subprocess.run`).
-5. **Phase 2a:** credential resolution order — real env beats file;
-   file beats prompt; command evaluated exactly once per process
-   (memoized); failing command → warning + prompt fallback.
-6. **Phase 2b:** command-valued `GRAFTPUNK_*` entry resolves at first
-   `get_settings()`; static `GRAFTPUNK_*` visible via Phase 1 with no
-   settings-code involvement.
-7. **CLI:** every verb via typer's `CliRunner` — `get` (hit, miss,
-   `--resolve` static, `--resolve` command via mocked subprocess), `set`
-   (new, replace, bad name), `unset` (present, absent), `list`, `path`,
-   `edit` (`$EDITOR` invocation mocked).
-8. **Bootstrap:** file path honors real-env `GRAFTPUNK_CONFIG_DIR`
-   without constructing settings.
+1. **Real-order static visibility:** file with static
+   `GRAFTPUNK_BROWSER_EXECUTABLE_PATH`; fresh-import the CLI module (its
+   import runs bootstrap injection then plugin discovery); assert
+   `get_settings().browser_executable_path` equals the file value —
+   this test fails if anyone ever moves injection after settings
+   construction.
+2. **Laziness regression:** file with command-valued credential AND
+   command-valued `GRAFTPUNK_*` entries; run `gp --help` and one
+   non-login plugin command through the real entry path; spy on
+   `subprocess.run` — assert **zero** invocations from
+   `workstation_env`.
+3. **Lazy field semantics:** command-valued `GRAFTPUNK_*` entry → not
+   evaluated at `get_settings()`; evaluated exactly once on first field
+   access; real-env-provided field never consults the file
+   (`model_fields_set` respected); failed command → pydantic default;
+   raw model returned (no proxy) when no command entries exist.
+4. **`lookup()` precedence:** real env beats file (including bootstrap-
+   injected statics); file beats `None`; command memoized (exactly one
+   subprocess across repeated lookups); failure memoized (no re-run);
+   empty-string env falls through to the file tier (intended change,
+   asserted).
+5. **Credential chain:** env miss → file resolve (subprocess mocked) →
+   prompt fallback on command failure; envvar-override plugins resolve
+   by their override names.
+6. **YAML header fallback:** `${VAR}` miss in `os.environ` resolves from
+   the file at command execution; still raises `PluginError` when both
+   miss.
+7. **Parser:** quote handling order (single-quoted `'$(x)'` is static;
+   double-quoted `"$(x)"` is a command; bare `$(x)` is a command; mixed
+   `pre$(x)post` is static + warning); inline `#` kept; malformed lines
+   warn and skip; duplicates → last wins.
+8. **Writer round-trip:** `set` preserves every non-target line
+   byte-for-byte; `set` of a new name appends; `unset` removes all
+   occurrences; 0600 after every write; atomic (temp + replace);
+   secret-keyword literal-value guardrail warns.
+9. **CLI verbs:** every verb via `CliRunner` — bare `gp config` renders
+   the migrated settings display; `show`; `get` (hit, miss, `--resolve`
+   static, `--resolve` command via mocked subprocess); `set` (new,
+   replace, bad name, guardrail); `unset` (present, absent, duplicated);
+   `list`; `path`; `edit` (`$VISUAL`/`$EDITOR`/`vi` precedence, mocked).
+10. **Paths:** `paths.config_dir()` honors real-env
+    `GRAFTPUNK_CONFIG_DIR` without constructing settings and creates no
+    directories; pydantic's `config_dir` default routes through it.

--- a/docs/rfcs/2026-07-28-workstation-env.md
+++ b/docs/rfcs/2026-07-28-workstation-env.md
@@ -1,5 +1,16 @@
 ---
 type: spec
+validated:
+  sha: dbf1db293582c116f7eea4a5bfa9e92e81fb6a2d
+  date: 2026-07-28T19:45:46Z
+  reviewers: [fact-check, solid-hygiene]
+  findings:
+    critical: 0
+    important: 6
+    medium: 1
+    low: 3
+    nitpick: 0
+  net_negative_remaining: 0
 ---
 
 # Workstation environment file + `gp config` (lazy credential & settings loading)
@@ -80,24 +91,37 @@ Precedence, owned by a single lookup function (see Components):
 
 - **Credentials:** real env → workstation file → interactive prompt.
 - **Settings (`GRAFTPUNK_*`):** real env → workstation file → cwd `.env`
-  (pydantic's existing `env_file` source) → field default. The
-  workstation file outranks cwd `.env` because statics are injected into
-  `os.environ` and pydantic ranks env above dotenv — this is intended
-  and documented: the workstation file is the machine-global answer, the
-  cwd `.env` remains a per-project override *only* for values the
-  workstation file doesn't set.
+  (pydantic's existing `env_file` source) → field default — and this
+  order holds for **both value kinds**. Statics: injected into
+  `os.environ`, and pydantic ranks env above dotenv. Command values
+  (allowlisted fields only): the proxy's source-aware gate skips a
+  field only when the *real environment* provides it; a merely
+  `.env`-provided field still yields to the workstation command value.
+  The workstation file is the machine-global answer; the cwd `.env`
+  remains a per-project override *only* for values the workstation file
+  doesn't set.
 - **YAML plugin headers:** real env → workstation file → existing
-  `PluginError` ("Environment variable $X is not set").
+  `PluginError` ("Environment variable $X is not set"), resolved
+  through the same single `lookup()` entry point.
 
 Other env reads exist and are **not** instrumented — by the laziness
 contract they work with static values (via bootstrap injection) but not
-command values. Known import-time accesses (static-only, documented):
+command values. Static-only is also the rule for `GRAFTPUNK_*` fields
+consumed by **model-internal** methods/properties (`supabase_url`,
+`supabase_service_key`, `s3_bucket` via `get_storage_config()`;
+`config_dir` via the `sessions_dir` property) — internal reads bind to
+the raw model and cannot see the lazy overlay, so command values there
+are warned about and ignored (see Consumption point (b)); supply those
+secrets via the real environment. Known import-time accesses
+(static-only, documented):
 `GRAFTPUNK_LOG_LEVEL` / `GRAFTPUNK_LOG_FORMAT` (`cli/main.py`, read at
 module scope for early logging — bootstrap injection precedes them, so
 file *statics* do work), `GRAFTPUNK_SESSION` (`session_context.py:27`),
-`GP_DOWNLOADS_DIR` (`plugins/export.py:35`), and `settings.plugins_dir`
-(accessed during import-time plugin discovery — a command value there
-would evaluate at import; keep it static).
+`GP_DOWNLOADS_DIR` (`plugins/export.py:35`), and `settings.config_dir`
+(accessed during import-time plugin discovery, which reads
+`settings.config_dir / "plugins"` — `yaml_loader.py:453`,
+`python_loader.py:128`; there is no separate `plugins_dir` setting, and
+an in-file `GRAFTPUNK_CONFIG_DIR` is already unsupported per § The file).
 
 ## The file
 
@@ -131,6 +155,15 @@ would evaluate at import; keep it static).
   - Malformed lines (no `=`, bad name): warn once with `file:line`,
     skip the line, continue.
   - Duplicate `NAME` lines: last one wins (shell semantics).
+
+> **Design note (2026-07-28):** this is deliberately a *second* env-file
+> dialect, distinct from the cwd `.env` pydantic parses — command-value
+> semantics can't be expressed in dotenv. To keep the delta enumerable:
+> the format diverges from dotenv conventions **only** where command
+> values require it (quote-kind meaning, whole-value `$()`, inline `#`
+> kept literal), `gp config list` surfaces each entry's `kind`
+> (`static`/`command`) so misclassifications are visible, and this
+> section is the single home of the divergence list.
 - **Permissions:** created `0600`; every CLI write re-asserts `0600`.
   On read, if the file is group- or world-readable, log a one-line
   warning (do not refuse).
@@ -175,14 +208,21 @@ The single owner of file knowledge **and** of the env-beats-file
 precedence rule. Import-light (imports `paths`, never `config`).
 
 - `load() -> WorkstationEnv` — parse the file (absent file → empty
-  instance), cached per-process.
+  instance), cached per-process. **Cache coherence contract:** the
+  writer functions (`set_entry`/`unset_entry`) invalidate this cache,
+  so a write-then-lookup in one process (tests, future in-process
+  callers) always sees fresh entries.
+- `ensure_bootstrap() -> None` — idempotent module-level function:
+  `load()` + `inject_static()` once per process. Called by
+  `get_settings()` (see Bootstrap section) and by `cli/main.py`.
 - `WorkstationEnv.inject_static() -> None` — bootstrap: for each static
   entry whose name is not already in `os.environ`, set it.
 - `WorkstationEnv.lookup(name: str) -> str | None` — **the public
   resolution entry point; the only implementation of the precedence
   rule.** Order: `os.environ` (hit → return it, including values
-  injected at bootstrap) → file entry (static → its value; command →
-  memoized result, else execute now, memoize, return) → `None`.
+  injected at bootstrap; an **empty-string value counts as a miss**) →
+  file entry (static → its value; command → memoized result, else
+  execute now, memoize, return) → `None`.
   Command failure (non-zero exit): log
   `workstation_env_command_failed` with the var name and the command's
   stderr, memoize the failure (never re-run a failing command in the
@@ -205,30 +245,37 @@ precedence rule. Import-light (imports `paths`, never `config`).
 Callers never sequence "check os.environ, then the file" by hand —
 that inversion-prone duplication is what `lookup()` exists to prevent.
 
-### Bootstrap hook — module scope of `cli/main.py`
+### Bootstrap — `ensure_bootstrap()`, owned by the settings chokepoint
 
-Immediately after imports, **before** the module-level
-`configure_logging` call (currently `cli/main.py:41-44`) and before
-`register_plugin_commands(app)` (currently `cli/main.py:810-812`):
+Static injection is **entry-path-agnostic**: `workstation_env` exposes
+an idempotent `ensure_bootstrap()` (parse file if needed, inject
+statics, mark done), and `get_settings()` calls it as its first
+statement — *before* first model construction. The ordering invariant
+("statics precede the singleton") is thereby owned structurally at the
+one chokepoint every consumer goes through: the CLI, and equally
+in-process **library consumers** (grocerbot drives
+`GraftpunkClient("shopkeep")` without ever importing `graftpunk.cli`)
+get identical behavior for statics and command values alike. No mixed
+reach: both mechanisms live at the same depth.
 
-```python
-from graftpunk import workstation_env
-workstation_env.load().inject_static()
-```
+`cli/main.py` additionally calls `ensure_bootstrap()` at module scope,
+immediately after imports and **before** the module-level
+`configure_logging` call (currently `cli/main.py:41-44`) — needed only
+so file *statics* for `GRAFTPUNK_LOG_LEVEL`/`GRAFTPUNK_LOG_FORMAT`
+take effect before early logging config (which reads `os.environ`
+directly and never constructs settings). Idempotence makes the double
+call free.
 
-This ordering is the design's load-bearing invariant, so it is owned
-structurally, not positionally: a lifecycle-faithful test (Testing #1)
-imports the real CLI module fresh and asserts injected statics are
-visible in `get_settings()` — any future re-ordering that constructs
-settings before injection fails that test. Because injection precedes
-the early logging config, file *statics* for
-`GRAFTPUNK_LOG_LEVEL`/`GRAFTPUNK_LOG_FORMAT` take effect too.
-
-Rationale for module scope rather than `main_callback()`: the settings
-singleton is constructed at import time — `register_plugin_commands`
-drives plugin discovery, which calls `get_settings()`
-(`plugins/yaml_loader.py:452`, `plugins/python_loader.py:127`) — so any
-hook inside a Typer callback runs after the singleton is frozen.
+Rationale for not hooking `main_callback()`: the settings singleton is
+constructed at import time — `register_plugin_commands`
+(`cli/main.py:810-812`) drives plugin discovery, which calls
+`get_settings()` (`plugins/yaml_loader.py:452`,
+`plugins/python_loader.py:127`) — so any hook inside a Typer callback
+runs after the singleton is frozen. With `ensure_bootstrap()` inside
+`get_settings()`, that import-time construction is itself what
+triggers injection, in order, everywhere. A lifecycle-faithful test
+(Testing #1) imports the real CLI module fresh and asserts injected
+statics are visible in `get_settings()`.
 
 ### Consumption point (a) — credential resolution (`cli/login_commands.py`)
 
@@ -256,40 +303,82 @@ through to the file tier first, then the prompt — intended.
 `get_settings()` keeps constructing the `GraftpunkSettings` singleton
 exactly as today (pydantic reads real env, injected statics, and cwd
 `.env` at construction). What changes is the return value when — and
-only when — the workstation file contains command-valued `GRAFTPUNK_*`
-entries for fields pydantic did not receive from any source
-(`model_fields_set`): `get_settings()` wraps the singleton in a
-`LazySettings` proxy (~50 lines, defined in `config.py`):
+only when — the workstation file contains command-valued entries for
+**proxy-safe** `GRAFTPUNK_*` fields: `get_settings()` wraps the
+singleton in a `LazySettings` proxy (~50 lines, defined in `config.py`).
 
-- `__getattr__(field)`: if `field` is in the lazy overlay (command
-  entry `GRAFTPUNK_<FIELD>` exists, field not provided by env/.env,
-  not yet resolved) → `workstation_env.load().lookup(...)`, coerce via
-  the field's pydantic `TypeAdapter`, cache on the proxy, return.
-  Otherwise delegate to the underlying model. Failed command → the
-  field's pydantic default (no `GraftpunkSettings` field is required,
-  so there is no missing-field error path; a bad value surfaces
-  downstream, e.g. `get_storage_config()`'s `ValueError` or a
-  browser-not-found failure).
-- When the file has no command-valued `GRAFTPUNK_*` entries (the common
-  case), `get_settings()` returns the raw model — zero overhead, zero
-  behavior change.
+**The overlay is bounded by an explicit allowlist, not implied
+universality.** The proxy intercepts only external attribute access;
+reads that happen *inside* the model's own methods and properties
+(`get_storage_config()`'s `self.supabase_service_key`/`self.s3_bucket`,
+the `sessions_dir` property's `self.config_dir`) bind to the raw model
+and can never see the overlay. Therefore:
+
+- `PROXY_SAFE_FIELDS` (in `config.py`, next to the model) enumerates
+  the leaf fields consumed only via external attribute access — today:
+  `browser_executable_path` (and future leaves added deliberately, with
+  the review question "is this field read model-internally?").
+- A command value targeting any **non**-allowlisted `GRAFTPUNK_*` field
+  warns at load time ("command values are unsupported for
+  GRAFTPUNK_X; treat as static-only") and is ignored by the overlay.
+  Fields consumed by model-internal methods (`supabase_*`, `s3_*`,
+  `config_dir`) join the documented static-only list alongside the
+  import-time accesses — real env remains the way to supply those
+  secrets.
+
+Proxy behavior for allowlisted fields:
+
+- `__getattr__(field)`: if `field` is in the lazy overlay (allowlisted,
+  command entry exists, **not provided by the real environment**, not
+  yet resolved) → `workstation_env.load().lookup(...)`, coerce via the
+  field's pydantic `TypeAdapter`, cache on the proxy, return. Otherwise
+  delegate to the underlying model. Failed command → the field's
+  pydantic default (no `GraftpunkSettings` field is required, so there
+  is no missing-field error path; a bad value surfaces downstream,
+  e.g. a browser-not-found failure).
+- **Source-aware precedence gate:** the overlay skips a field only when
+  its env var name is present in `os.environ` (real env or
+  bootstrap-injected static — env wins). A field provided merely by a
+  cwd `.env` still yields to the workstation command value, so the
+  documented order — real env → workstation file → cwd `.env` → default
+  — holds for **both** value kinds and is decided in exactly one place
+  (this gate). `model_fields_set` is not used for precedence: it cannot
+  distinguish env-provided from dotenv-provided.
+- The overlay's env-var names are derived from the model's own
+  settings metadata (`env_prefix` + field aliases), not re-assembled by
+  hand — pydantic stays the single authority for the field→envvar
+  mapping.
+- When the file has no command-valued entries for allowlisted fields
+  (the common case), `get_settings()` returns the raw model — zero
+  overhead, zero behavior change.
 
 Consequences, per the laziness contract: `gp --help` constructs the
 proxy but accesses no lazy field → zero evaluations. A command-valued
-`GRAFTPUNK_BROWSER_EXECUTABLE_PATH` evaluates when session start first
-reads it (`session.py:130`) — inside a login, exactly where the cost
-belongs. A command-valued `plugins_dir` would evaluate at import
-(discovery accesses it); the contract says keep such fields static.
+`GRAFTPUNK_BROWSER_EXECUTABLE_PATH` evaluates when `BrowserSession`
+construction first reads it (`session.py:130`) — inside a login, exactly
+where the cost belongs. A command-valued `config_dir` would evaluate at
+import (discovery accesses `settings.config_dir`) — but an in-file
+`GRAFTPUNK_CONFIG_DIR` is already unsupported (see § The file).
 
 ### Consumption point (c) — YAML plugin header expansion
 
 `expand_env_vars` (`plugins/yaml_loader.py:124-146`), invoked at
 command-execution time from `plugins/yaml_plugin.py:126-128`, currently
-raises `PluginError` when `os.environ` lacks `${VAR}`. It gains a
-one-line fallback: on miss, consult `workstation_env.load().lookup(var)`
-before raising. This makes API-key-style headers first-class lazy
-consumers — the evaluation happens when that plugin command actually
-runs.
+reads `os.environ.get` itself and raises `PluginError` when `${VAR}` is
+unset. Its env read is **replaced** by the single precedence-owning
+entry point — symmetrical with consumption point (a): the replacer
+resolves each `${VAR}` via `workstation_env.load().lookup(var)` alone
+and raises the existing `PluginError` on `None`. No call-site
+env-then-file sequencing survives anywhere; `lookup()` remains the only
+implementation of the precedence rule across all three consumers. This
+makes API-key-style headers first-class lazy consumers — evaluation
+happens when that plugin command actually runs.
+
+One deliberate behavior change, same as point (a) and documented once
+in `lookup()`'s contract: an **empty-string** environment variable
+counts as a miss and falls through to the file tier (previously
+`expand_env_vars` treated empty-as-set). Unified semantics across all
+three consumption points.
 
 ### `gp config` command family (`cli/config_commands.py`, new)
 
@@ -310,7 +399,7 @@ in the same change.
 | `gp config path` | Print the workstation env file's absolute path (whether or not it exists). |
 | `gp config list` | Print `NAME=raw_value` per entry, file order. Commands display unevaluated. Nothing is masked — the convention keeps secrets behind `$(…)`; a literal secret stored against convention IS printed, an acknowledged residual exposure consistent with the 0600 posture. Absent/empty file → no output, exit 0. |
 | `gp config get NAME` | Print the raw stored value. Exit 1, message on stderr, if unset. |
-| `gp config get NAME --resolve` | Evaluate a command value and print the result (explicit opt-in to printing a secret, same posture as `op read`). Static values print verbatim. Failed command → its stderr and exit 1. |
+| `gp config get NAME --resolve` | Evaluate a command value and print the result (explicit opt-in to printing a secret, same posture as `op read`). Static values print verbatim. Failed command → its stderr and exit 1. Deliberately inspects the file's stored value directly, bypassing the env→file precedence — it answers "what does the *file* say," not "what would `lookup()` return"; the one intentional exception to lookup()-only resolution. |
 | `gp config set NAME VALUE` | Validate `NAME` against `[A-Za-z_][A-Za-z0-9_]*`; write/replace surgically; create file (0600) and parent dir if needed. `VALUE` stored verbatim — the operator's shell quoting (`'$(op read …)'`) is what defers evaluation. **Guardrail:** when `NAME` contains a secret keyword (`password`/`secret`/`token`/`key`, matching `login_commands.py:106`) and `VALUE` contains no `$(`, warn: the operator's shell may have already substituted an unquoted `$(op read …)`, and a plaintext secret is being written to disk. Warn, don't refuse. |
 | `gp config unset NAME` | Remove **all** occurrences (see writer semantics). Exit 0 even if absent (idempotent). |
 | `gp config edit` | Open the file in `$VISUAL`, else `$EDITOR`, else `vi`; create the file first if absent. |
@@ -381,22 +470,29 @@ phases called in an assumed order.
    non-login plugin command through the real entry path; spy on
    `subprocess.run` — assert **zero** invocations from
    `workstation_env`.
-3. **Lazy field semantics:** command-valued `GRAFTPUNK_*` entry → not
-   evaluated at `get_settings()`; evaluated exactly once on first field
-   access; real-env-provided field never consults the file
-   (`model_fields_set` respected); failed command → pydantic default;
-   raw model returned (no proxy) when no command entries exist.
+3. **Lazy field semantics:** command-valued entry for an allowlisted
+   field → not evaluated at `get_settings()`; evaluated exactly once on
+   first field access; **source-aware gate:** real-env-provided field
+   never consults the file, but a field provided only by cwd `.env`
+   yields to the workstation command value (documented order holds for
+   both value kinds); failed command → pydantic default; raw model
+   returned (no proxy) when no allowlisted command entries exist;
+   command value targeting a NON-allowlisted `GRAFTPUNK_*` field warns
+   at load and is ignored by the overlay; overlay env names derived
+   from model metadata, not hand-assembled.
 4. **`lookup()` precedence:** real env beats file (including bootstrap-
    injected statics); file beats `None`; command memoized (exactly one
    subprocess across repeated lookups); failure memoized (no re-run);
    empty-string env falls through to the file tier (intended change,
-   asserted).
+   asserted); `set_entry`/`unset_entry` invalidate the `load()` cache
+   (write-then-lookup sees fresh entries).
 5. **Credential chain:** env miss → file resolve (subprocess mocked) →
    prompt fallback on command failure; envvar-override plugins resolve
    by their override names.
-6. **YAML header fallback:** `${VAR}` miss in `os.environ` resolves from
-   the file at command execution; still raises `PluginError` when both
-   miss.
+6. **YAML header resolution:** `${VAR}` resolves through `lookup()`
+   alone at command execution (env hit, file static, file command each
+   asserted); raises `PluginError` on `None`; empty-string env falls
+   through to the file tier here too (unified semantics asserted).
 7. **Parser:** quote handling order (single-quoted `'$(x)'` is static;
    double-quoted `"$(x)"` is a command; bare `$(x)` is a command; mixed
    `pre$(x)post` is static + warning); inline `#` kept; malformed lines
@@ -413,3 +509,8 @@ phases called in an assumed order.
 10. **Paths:** `paths.config_dir()` honors real-env
     `GRAFTPUNK_CONFIG_DIR` without constructing settings and creates no
     directories; pydantic's `config_dir` default routes through it.
+11. **Library reach:** a consumer that never imports `graftpunk.cli`
+    (constructs `GraftpunkClient` / calls `get_settings()` directly)
+    sees file statics and allowlisted command values identically to the
+    CLI — `ensure_bootstrap()` inside `get_settings()` asserted via a
+    fresh-import test that touches no CLI module.

--- a/docs/rfcs/2026-07-28-workstation-env.md
+++ b/docs/rfcs/2026-07-28-workstation-env.md
@@ -104,9 +104,28 @@ Precedence, owned by a single lookup function (see Components):
   `PluginError` ("Environment variable $X is not set"), resolved
   through the same single `lookup()` entry point.
 
+> **Known limitation (case sensitivity):** pydantic-settings matches env
+> var names **case-insensitively**, so `graftpunk_browser_executable_path`
+> (lowercase, in the real environment) satisfies the model directly. But
+> `lookup()` and the lazy proxy's source-aware gate (`_build_lazy_field_map`)
+> both check `os.environ` **case-sensitively** against the derived
+> `GRAFTPUNK_*` uppercase name — so a lowercase real-env var loses to a
+> workstation-file command value instead of winning, contradicting "real
+> env always wins." Nobody hits this today because the documented naming
+> convention is the derived uppercase name; use that. A behavioral fix
+> would mean either lookup() also probing case-insensitively (touches its
+> contract for every consumer, not just this one) or normalizing names at
+> the file-parsing boundary — deferred until a real workstation-env
+> operator actually sets a lowercase name.
+
 Other env reads exist and are **not** instrumented — by the laziness
 contract they work with static values (via bootstrap injection) but not
-command values. Static-only is also the rule for `GRAFTPUNK_*` fields
+command values. Un-instrumented but command-time (statics work; these are
+plain `os.environ.get()` calls inside a function body, evaluated whenever
+that function actually runs — not at import time): `GRAFTPUNK_SESSION`
+(`session_context.py:27`, inside `get_active_session()`) and
+`GP_DOWNLOADS_DIR` (`plugins/export.py:35`, inside `get_downloads_dir()`).
+Static-only is also the rule for `GRAFTPUNK_*` fields
 consumed by **model-internal** methods/properties (`supabase_url`,
 `supabase_service_key`, `s3_bucket` via `get_storage_config()`;
 `config_dir` via the `sessions_dir` property) — internal reads bind to
@@ -116,8 +135,7 @@ secrets via the real environment. Known import-time accesses
 (static-only, documented):
 `GRAFTPUNK_LOG_LEVEL` / `GRAFTPUNK_LOG_FORMAT` (`cli/main.py`, read at
 module scope for early logging — bootstrap injection precedes them, so
-file *statics* do work), `GRAFTPUNK_SESSION` (`session_context.py:27`),
-`GP_DOWNLOADS_DIR` (`plugins/export.py:35`), and `settings.config_dir`
+file *statics* do work), and `settings.config_dir`
 (accessed during import-time plugin discovery, which reads
 `settings.config_dir / "plugins"` — `yaml_loader.py:453`,
 `python_loader.py:128`; there is no separate `plugins_dir` setting, and

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -137,4 +137,12 @@ def edit_cmd() -> None:
     """Open the workstation env file in $VISUAL, else $EDITOR, else vi."""
     workstation_env.ensure_file()
     editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
-    raise typer.Exit(subprocess.call([editor, str(paths.workstation_env_path())]))  # noqa: S603
+    env_path = paths.workstation_env_path()
+    exit_code = subprocess.call([editor, str(env_path)])  # noqa: S603
+    # Some editors write via a temp-file-then-rename (replace-on-write),
+    # which leaves the new inode with the process umask's permissions
+    # rather than preserving the original 0600 -- re-assert it here so
+    # every write path (not just workstation_env's own writers) honors the
+    # spec's "every CLI write is 0600" invariant.
+    os.chmod(env_path, 0o600)
+    raise typer.Exit(exit_code)

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -1,0 +1,151 @@
+"""gp config — inspect and manage graftpunk configuration.
+
+Bare `gp config` renders the settings panel (behavior migrated verbatim from
+the old root-level command); the verbs manage the workstation env file
+(spec: docs/rfcs/2026-07-28-workstation-env.md).
+"""
+
+import os
+import subprocess
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from graftpunk import paths, workstation_env
+from graftpunk.cli.login_commands import SECRET_KEYWORDS
+
+console = Console()
+err_console = Console(stderr=True)
+
+config_app = typer.Typer(
+    name="config",
+    help="Show configuration; manage the workstation env file.",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+
+
+def render_settings_panel(target_console: Console) -> None:
+    """The settings display formerly at `gp config` (migrated verbatim).
+
+    get_settings is imported here (from graftpunk.cli.main, not
+    graftpunk.config) rather than at module scope: pre-existing tests in
+    tests/unit/test_cli.py patch `graftpunk.cli.main.get_settings` (written
+    when this command lived in main.py). A deferred, call-time attribute
+    lookup on the main module is what lets those patches keep taking effect
+    after the move — a module-scope `from graftpunk.config import
+    get_settings` here would bind its own reference and silently ignore
+    that patch target.
+    """
+    from graftpunk.cli.main import get_settings
+
+    settings = get_settings()
+
+    storage_display = settings.storage_backend
+    if settings.storage_backend == "supabase":
+        storage_display = f"{settings.storage_backend} [dim](cloud)[/dim]"
+    elif settings.storage_backend == "local":
+        storage_display = f"{settings.storage_backend} [dim](filesystem)[/dim]"
+
+    info = f"""
+[dim]Config directory:[/dim]   {settings.config_dir}
+[dim]Sessions directory:[/dim] {settings.sessions_dir}
+[dim]Storage backend:[/dim]    {storage_display}
+[dim]Session TTL:[/dim]        {settings.session_ttl_hours}h ({settings.session_ttl_hours // 24}d)
+[dim]Log level:[/dim]          {settings.log_level}
+[dim]Log format:[/dim]         {settings.log_format}"""
+
+    target_console.print(Panel(info.strip(), title="⚙ Configuration", border_style="cyan"))
+
+
+@config_app.callback(invoke_without_command=True)
+def config_root(ctx: typer.Context) -> None:
+    """Show current graftpunk configuration."""
+    if ctx.invoked_subcommand is None:
+        render_settings_panel(console)
+
+
+@config_app.command("show")
+def show() -> None:
+    """Show current graftpunk configuration."""
+    render_settings_panel(console)
+
+
+@config_app.command("path")
+def path_cmd() -> None:
+    """Print the workstation env file's path."""
+    typer.echo(str(paths.workstation_env_path()))
+
+
+@config_app.command("list")
+def list_cmd() -> None:
+    """List workstation env entries (raw values; commands unevaluated).
+
+    Command entries carry a trailing `[command]` marker — per the spec's
+    design note, list surfaces each entry's kind so misclassifications
+    (e.g. an accidentally-static secret) are visible at a glance.
+    """
+    for entry in workstation_env.load().entries():
+        suffix = "  [command]" if entry.kind == workstation_env.COMMAND else ""
+        typer.echo(f"{entry.name}={entry.raw_value}{suffix}")
+
+
+@config_app.command("get")
+def get_cmd(
+    name: str,
+    resolve: bool = typer.Option(
+        False,
+        "--resolve",
+        help="Evaluate a command value and print the result (may print a secret). "
+        "Inspects the FILE's stored value directly — the one intentional "
+        "exception to lookup()-only resolution.",
+    ),
+) -> None:
+    """Print the raw stored value for NAME (or resolve it with --resolve)."""
+    entry = workstation_env.load().get(name)
+    if entry is None:
+        err_console.print(f"[red]{name} is not set in {paths.workstation_env_path()}[/red]")
+        raise typer.Exit(1)
+    if not resolve:
+        typer.echo(entry.raw_value)
+        return
+    # File-tier resolution via the module's primitive — command-execution
+    # mechanics stay with their single owner (workstation_env).
+    value = workstation_env.load().resolve_file_value(name)
+    if value is None:
+        err_console.print(f"[red]command for {name} failed (see log output)[/red]")
+        raise typer.Exit(1)
+    typer.echo(value)
+
+
+@config_app.command("set")
+def set_cmd(name: str, value: str) -> None:
+    """Add or replace NAME=VALUE (stored verbatim; quote $(…) in your shell)."""
+    try:
+        workstation_env.set_entry(name, value)
+    except ValueError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+    is_secret_name = any(kw in name.lower() for kw in SECRET_KEYWORDS)
+    if is_secret_name and "$(" not in value:
+        err_console.print(
+            f"[yellow]warning:[/yellow] {name} looks secret but the value is a "
+            "literal — if you meant a command, single-quote it: "
+            f"gp config set {name} '$(op read ...)'. A plaintext secret is now "
+            "on disk (0600)."
+        )
+
+
+@config_app.command("unset")
+def unset_cmd(name: str) -> None:
+    """Remove NAME (all occurrences). Idempotent."""
+    workstation_env.unset_entry(name)
+
+
+@config_app.command("edit")
+def edit_cmd() -> None:
+    """Open the workstation env file in $VISUAL, else $EDITOR, else vi."""
+    workstation_env.ensure_file()
+    editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
+    raise typer.Exit(subprocess.call([editor, str(paths.workstation_env_path())]))  # noqa: S603

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -101,9 +101,14 @@ def get_cmd(
         return
     # File-tier resolution via the module's primitive — command-execution
     # mechanics stay with their single owner (workstation_env).
-    value = workstation_env.load().resolve_file_value(name)
+    env = workstation_env.load()
+    value = env.resolve_file_value(name)
     if value is None:
-        err_console.print(f"[red]command for {name} failed (see log output)[/red]")
+        stderr = env.last_resolve_error(name)
+        if stderr:
+            err_console.print(f"[red]command for {name} failed:[/red] {stderr}")
+        else:
+            err_console.print(f"[red]command for {name} failed (see log output)[/red]")
         raise typer.Exit(1)
     typer.echo(value)
 

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 
 from graftpunk import paths, workstation_env
 from graftpunk.cli.login_commands import SECRET_KEYWORDS
+from graftpunk.config import get_settings
 
 console = Console()
 err_console = Console(stderr=True)
@@ -27,19 +28,7 @@ config_app = typer.Typer(
 
 
 def render_settings_panel(target_console: Console) -> None:
-    """The settings display formerly at `gp config` (migrated verbatim).
-
-    get_settings is imported here (from graftpunk.cli.main, not
-    graftpunk.config) rather than at module scope: pre-existing tests in
-    tests/unit/test_cli.py patch `graftpunk.cli.main.get_settings` (written
-    when this command lived in main.py). A deferred, call-time attribute
-    lookup on the main module is what lets those patches keep taking effect
-    after the move — a module-scope `from graftpunk.config import
-    get_settings` here would bind its own reference and silently ignore
-    that patch target.
-    """
-    from graftpunk.cli.main import get_settings
-
+    """The settings display formerly at `gp config` (migrated verbatim)."""
     settings = get_settings()
 
     storage_display = settings.storage_backend

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -6,6 +6,7 @@ the old root-level command); the verbs manage the workstation env file
 """
 
 import os
+import shlex
 import subprocess
 
 import typer
@@ -106,7 +107,19 @@ def get_cmd(
     if value is None:
         stderr = env.last_resolve_error(name)
         if stderr:
-            err_console.print(f"[red]command for {name} failed:[/red] {stderr}")
+            # markup=False: stderr is arbitrary foreign-process output, not
+            # ours to interpret as Rich markup -- a literal "[flags]" token
+            # would otherwise vanish, and an unbalanced "[/...]" token would
+            # raise MarkupError. highlight=False: Rich's automatic repr
+            # highlighter would otherwise still wrap bracketed substrings
+            # in ANSI styling of its own. style="red" keeps the visual
+            # treatment without touching the text itself.
+            err_console.print(
+                f"command for {name} failed: {stderr}",
+                style="red",
+                markup=False,
+                highlight=False,
+            )
         else:
             err_console.print(f"[red]command for {name} failed (see log output)[/red]")
         raise typer.Exit(1)
@@ -136,7 +149,10 @@ def unset_cmd(name: str) -> None:
     """Remove NAME (all occurrences). Idempotent."""
     try:
         workstation_env.unset_entry(name)
-    except OSError as exc:
+    except (ValueError, OSError) as exc:
+        # ValueError covers UnicodeDecodeError: unset_entry() reads the
+        # file directly (it must diff line-by-line, unlike load(), which
+        # already degrades a non-UTF-8 file to "empty" via its own guard).
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
 
@@ -144,14 +160,28 @@ def unset_cmd(name: str) -> None:
 @config_app.command("edit")
 def edit_cmd() -> None:
     """Open the workstation env file in $VISUAL, else $EDITOR, else vi."""
-    workstation_env.ensure_file()
     editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
     env_path = paths.workstation_env_path()
-    exit_code = subprocess.call([editor, str(env_path)])  # noqa: S603
-    # Some editors write via a temp-file-then-rename (replace-on-write),
-    # which leaves the new inode with the process umask's permissions
-    # rather than preserving the original 0600 -- re-assert it here so
-    # every write path (not just workstation_env's own writers) honors the
-    # spec's "every CLI write is 0600" invariant.
-    os.chmod(env_path, 0o600)
+    try:
+        workstation_env.ensure_file()
+        # shlex.split: $EDITOR/$VISUAL commonly carry flags (e.g.
+        # `EDITOR="code --wait"`) -- passing the whole string as argv[0]
+        # would exec a binary literally named "code --wait" and fail.
+        argv = [*shlex.split(editor), str(env_path)]
+        exit_code = subprocess.call(argv)  # noqa: S603
+        # Some editors write via a temp-file-then-rename (replace-on-write),
+        # which leaves the new inode with the process umask's permissions
+        # rather than preserving the original 0600 -- re-assert it here so
+        # every write path (not just workstation_env's own writers) honors
+        # the spec's "every CLI write is 0600" invariant. An editor that
+        # deleted the file outright isn't our error to report -- skip the
+        # chmod and propagate the editor's own exit code below.
+        if env_path.is_file():
+            os.chmod(env_path, 0o600)
+    except OSError as exc:
+        # Covers ensure_file()/chmod failures and, notably, the editor
+        # binary itself being missing (subprocess.call raises
+        # FileNotFoundError rather than returning a nonzero exit code).
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
     raise typer.Exit(exit_code)

--- a/src/graftpunk/cli/config_commands.py
+++ b/src/graftpunk/cli/config_commands.py
@@ -113,7 +113,7 @@ def set_cmd(name: str, value: str) -> None:
     """Add or replace NAME=VALUE (stored verbatim; quote $(…) in your shell)."""
     try:
         workstation_env.set_entry(name, value)
-    except ValueError as exc:
+    except (ValueError, OSError) as exc:
         err_console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
     is_secret_name = any(kw in name.lower() for kw in SECRET_KEYWORDS)
@@ -129,7 +129,11 @@ def set_cmd(name: str, value: str) -> None:
 @config_app.command("unset")
 def unset_cmd(name: str) -> None:
     """Remove NAME (all occurrences). Idempotent."""
-    workstation_env.unset_entry(name)
+    try:
+        workstation_env.unset_entry(name)
+    except OSError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
 
 
 @config_app.command("edit")

--- a/src/graftpunk/cli/login_commands.py
+++ b/src/graftpunk/cli/login_commands.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import os
 from collections.abc import Callable
 from typing import Any
 
@@ -16,6 +15,7 @@ import typer
 from rich.status import Status
 
 from graftpunk import console as gp_console
+from graftpunk import workstation_env
 from graftpunk.logging import get_logger
 from graftpunk.plugins.cli_plugin import (
     CLIPluginProtocol,
@@ -103,10 +103,11 @@ def make_login_body(
 ) -> Callable[..., None]:
     """Build the login command BODY: credential resolution -> login callable.
 
-    Credential resolution order (unchanged): environment variables
-    ({SITE_PREFIX}_{FIELD} or plugin-level username_envvar/password_envvar
-    overrides), then interactive prompts (masked for password/secret/token/key
-    fields). The resolved credentials dict is passed INTO the login callable.
+    Credential resolution order: environment variables ({SITE_PREFIX}_{FIELD}
+    or plugin-level username_envvar/password_envvar overrides), then the
+    workstation env file (static or $(…) command values, resolved lazily), then
+    interactive prompts (masked for password/secret/token/key fields).
+    The resolved credentials dict is passed INTO the login callable.
     """
     secret_keywords = SECRET_KEYWORDS
 
@@ -127,12 +128,15 @@ def make_login_body(
             is_secret = any(kw in field_name.lower() for kw in secret_keywords)
             envvar = envvar_overrides.get(field_name, f"{site_prefix}_{field_name.upper()}")
 
-            env_value = os.environ.get(envvar)
+            # env -> workstation file, via the single precedence-owning
+            # lookup() (empty-string env counts as a miss and falls through
+            # to the file tier — deliberate change from the old
+            # login_envvar_empty behavior). Command values (e.g.
+            # $(op read ...)) execute here, at login time only.
+            env_value = workstation_env.load().lookup(envvar)
             if env_value:
                 credentials[field_name] = env_value
             else:
-                if env_value is not None:
-                    LOG.debug("login_envvar_empty", field=field_name, envvar=envvar)
                 credentials[field_name] = typer.prompt(
                     field_name.replace("_", " ").title(),
                     hide_input=is_secret,

--- a/src/graftpunk/cli/login_commands.py
+++ b/src/graftpunk/cli/login_commands.py
@@ -26,6 +26,11 @@ from graftpunk.plugins.login_engine import generate_login_method
 
 LOG = get_logger(__name__)
 
+# Field-name keywords that mark a credential as secret. Shared policy:
+# make_login_body masks prompts with it, and gp config's set guardrail
+# (cli/config_commands.py) warns on literal values for such names.
+SECRET_KEYWORDS = frozenset({"password", "secret", "token", "key"})
+
 
 def has_login_method(plugin: CLIPluginProtocol) -> bool:
     """Check if plugin has a login method that's not a CLI command.
@@ -103,7 +108,7 @@ def make_login_body(
     overrides), then interactive prompts (masked for password/secret/token/key
     fields). The resolved credentials dict is passed INTO the login callable.
     """
-    secret_keywords = {"password", "secret", "token", "key"}
+    secret_keywords = SECRET_KEYWORDS
 
     envvar_overrides: dict[str, str] = {}
     username_envvar = getattr(plugin, "username_envvar", "")

--- a/src/graftpunk/cli/main.py
+++ b/src/graftpunk/cli/main.py
@@ -18,6 +18,13 @@ from rich.panel import Panel
 from rich.table import Table
 
 import graftpunk
+
+# Workstation env bootstrap MUST precede the early logging config below so
+# file statics for GRAFTPUNK_LOG_LEVEL/GRAFTPUNK_LOG_FORMAT take effect, and
+# precede plugin registration (which constructs the settings singleton).
+# get_settings() also calls ensure_bootstrap() — idempotent, order-owned there.
+from graftpunk import workstation_env
+from graftpunk.cli.config_commands import config_app
 from graftpunk.cli.http_commands import http_app
 from graftpunk.cli.keepalive_commands import keepalive_app
 from graftpunk.cli.plugin_commands import resolve_session_name
@@ -33,6 +40,8 @@ from graftpunk.plugins import (
 )
 from graftpunk.plugins.yaml_plugin import create_yaml_plugins
 from graftpunk.session_context import resolve_session
+
+workstation_env.ensure_bootstrap()
 
 # Configure logging early (before plugin registration) using env vars directly.
 # We avoid calling get_settings() here because GraftpunkSettings.__init__ creates
@@ -58,7 +67,7 @@ app = typer.Typer(
       gp session list          Show all cached sessions
       gp session show <name>   View session details
       gp session clear <name>  Remove a session
-      gp config                Show current configuration
+      gp config                Show config / manage the workstation env file
 
     \b
     Documentation: https://github.com/stavxyz/graftpunk
@@ -664,6 +673,9 @@ app.add_typer(keepalive_app)
 # HTTP subcommand group (defined in http_commands.py)
 app.add_typer(http_app)
 
+# Config subcommand group (defined in config_commands.py)
+app.add_typer(config_app)
+
 
 @app.command("plugins")
 def plugins() -> None:
@@ -779,28 +791,6 @@ def import_har_cmd(
         discover_api=discover_api,
         dry_run=dry_run,
     )
-
-
-@app.command("config")
-def config() -> None:
-    """Show current graftpunk configuration."""
-    settings = get_settings()
-
-    storage_display = settings.storage_backend
-    if settings.storage_backend == "supabase":
-        storage_display = f"{settings.storage_backend} [dim](cloud)[/dim]"
-    elif settings.storage_backend == "local":
-        storage_display = f"{settings.storage_backend} [dim](filesystem)[/dim]"
-
-    info = f"""
-[dim]Config directory:[/dim]   {settings.config_dir}
-[dim]Sessions directory:[/dim] {settings.sessions_dir}
-[dim]Storage backend:[/dim]    {storage_display}
-[dim]Session TTL:[/dim]        {settings.session_ttl_hours}h ({settings.session_ttl_hours // 24}d)
-[dim]Log level:[/dim]          {settings.log_level}
-[dim]Log format:[/dim]         {settings.log_format}"""
-
-    console.print(Panel(info.strip(), title="⚙ Configuration", border_style="cyan"))
 
 
 # Register plugin commands dynamically at module load time so they appear in --help.

--- a/src/graftpunk/cli/main.py
+++ b/src/graftpunk/cli/main.py
@@ -19,10 +19,13 @@ from rich.table import Table
 
 import graftpunk
 
-# Workstation env bootstrap MUST precede the early logging config below so
-# file statics for GRAFTPUNK_LOG_LEVEL/GRAFTPUNK_LOG_FORMAT take effect, and
-# precede plugin registration (which constructs the settings singleton).
-# get_settings() also calls ensure_bootstrap() — idempotent, order-owned there.
+# Workstation env bootstrap MUST precede plugin registration below (which
+# constructs the settings singleton) so file statics are visible to it.
+# It's sandwiched between two configure_logging() calls below: the first
+# (pre-bootstrap) ensures any warning bootstrap itself emits goes to stderr,
+# the second (post-bootstrap) picks up file statics for
+# GRAFTPUNK_LOG_LEVEL/GRAFTPUNK_LOG_FORMAT. get_settings() also calls
+# ensure_bootstrap() — idempotent, order-owned there.
 from graftpunk import workstation_env
 from graftpunk.cli.config_commands import config_app
 from graftpunk.cli.http_commands import http_app
@@ -41,11 +44,26 @@ from graftpunk.plugins import (
 from graftpunk.plugins.yaml_plugin import create_yaml_plugins
 from graftpunk.session_context import resolve_session
 
+# Configure logging BEFORE workstation-env bootstrap so any warning
+# ensure_bootstrap() emits (permissive file mode, malformed line, mixed
+# substitution) routes through structlog's configured stderr renderer
+# instead of structlog's default PrintLoggerFactory (stdout) -- which would
+# otherwise corrupt piped `gp` output for CSV/JSON consumers. We avoid
+# calling get_settings() here because GraftpunkSettings.__init__ creates
+# directories as a side effect, which breaks test isolation; env vars are
+# read directly instead.
+configure_logging(
+    level=os.environ.get("GRAFTPUNK_LOG_LEVEL", "WARNING"),
+    json_output=os.environ.get("GRAFTPUNK_LOG_FORMAT", "console") == "json",
+)
+
 workstation_env.ensure_bootstrap()
 
-# Configure logging early (before plugin registration) using env vars directly.
-# We avoid calling get_settings() here because GraftpunkSettings.__init__ creates
-# directories as a side effect, which breaks test isolation.
+# Re-configure logging: ensure_bootstrap() may have just injected file-static
+# GRAFTPUNK_LOG_LEVEL/GRAFTPUNK_LOG_FORMAT into os.environ (only when the
+# real env didn't already set them), so re-read them now. configure_logging()
+# is idempotent, so this is a no-op unless the file actually changed one of
+# those two vars.
 # The -v/-vv and --log-format flags in main_callback() may reconfigure later.
 configure_logging(
     level=os.environ.get("GRAFTPUNK_LOG_LEVEL", "WARNING"),

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -270,6 +270,11 @@ def _build_lazy_field_map() -> dict[str, str]:
 
 
 # Global settings instance
+# NOTE: this singleton (including a LazySettings proxy's per-field _resolved
+# cache) is intentionally NOT invalidated by workstation-env writes
+# (set_entry()/unset_entry()) -- only workstation_env's own load()/lookup()
+# guarantee write-then-lookup coherence. Call reset_settings() explicitly to
+# see a workstation-env write reflected in settings (tests already do this).
 _settings: "GraftpunkSettings | LazySettings | None" = None
 
 

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -192,14 +192,14 @@ class LazySettings:
     holds for both value kinds and is decided here alone.
     """
 
-    def __init__(self, model: GraftpunkSettings, lazy_fields: dict[str, str]):
+    def __init__(self, model: GraftpunkSettings, lazy_fields: dict[str, str]) -> None:
         # lazy_fields: field name -> env var name (derived from model config,
         # pydantic stays the single authority for the mapping)
         object.__setattr__(self, "_model", model)
         object.__setattr__(self, "_lazy_fields", lazy_fields)
         object.__setattr__(self, "_resolved", {})
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         lazy_fields = object.__getattribute__(self, "_lazy_fields")
         if name in lazy_fields:
             resolved = object.__getattribute__(self, "_resolved")
@@ -214,6 +214,14 @@ class LazySettings:
                     resolved[name] = getattr(model, name)
                 else:
                     adapter = TypeAdapter(GraftpunkSettings.model_fields[name].annotation)
+                    # NOTE: a command's output that fails this field's
+                    # TypeAdapter coercion raises a raw pydantic
+                    # ValidationError here, with no workstation-file
+                    # context (which entry, which line) attached.
+                    # Unreachable today -- browser_executable_path accepts
+                    # any str, so coercion can't fail -- but a trap the
+                    # moment PROXY_SAFE_FIELDS grows to include a field
+                    # whose type isn't just "any string".
                     resolved[name] = adapter.validate_python(raw)
             return resolved[name]
         return getattr(object.__getattribute__(self, "_model"), name)

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -173,24 +173,110 @@ class GraftpunkSettings(BaseSettings):
         )
 
 
+# Leaf fields consumed ONLY via external attribute access — safe for the
+# lazy overlay. Reads that happen INSIDE model methods/properties
+# (get_storage_config()'s supabase_*/s3_*, sessions_dir's config_dir) bind
+# to the raw model and can never see the overlay, so command values for
+# those fields are unsupported (warned + ignored; supply via real env).
+PROXY_SAFE_FIELDS = frozenset({"browser_executable_path"})
+
+
+class LazySettings:
+    """Bounded lazy overlay over GraftpunkSettings.
+
+    Resolves command-valued workstation-env entries for PROXY_SAFE_FIELDS on
+    first attribute access. Source-aware precedence gate: the overlay is
+    skipped only when the REAL environment provides the field (a merely
+    .env-provided value still yields to the workstation command value), so
+    the documented order — real env > workstation file > cwd .env > default —
+    holds for both value kinds and is decided here alone.
+    """
+
+    def __init__(self, model: GraftpunkSettings, lazy_fields: dict[str, str]):
+        # lazy_fields: field name -> env var name (derived from model config,
+        # pydantic stays the single authority for the mapping)
+        object.__setattr__(self, "_model", model)
+        object.__setattr__(self, "_lazy_fields", lazy_fields)
+        object.__setattr__(self, "_resolved", {})
+
+    def __getattr__(self, name: str):
+        lazy_fields = object.__getattribute__(self, "_lazy_fields")
+        if name in lazy_fields:
+            resolved = object.__getattribute__(self, "_resolved")
+            if name not in resolved:
+                from pydantic import TypeAdapter
+
+                from graftpunk import workstation_env
+
+                raw = workstation_env.load().lookup(lazy_fields[name])
+                model = object.__getattribute__(self, "_model")
+                if raw is None:
+                    resolved[name] = getattr(model, name)
+                else:
+                    adapter = TypeAdapter(GraftpunkSettings.model_fields[name].annotation)
+                    resolved[name] = adapter.validate_python(raw)
+            return resolved[name]
+        return getattr(object.__getattribute__(self, "_model"), name)
+
+
+def _field_env_name(field_name: str) -> str:
+    """Derive the env var name from the model's own settings config."""
+    prefix = GraftpunkSettings.model_config.get("env_prefix", "")
+    return f"{prefix}{field_name}".upper()
+
+
+def _build_lazy_field_map() -> dict[str, str]:
+    """Map allowlisted field -> env var for command entries the real env
+    doesn't override. Warns about command entries targeting non-allowlisted
+    GRAFTPUNK_* fields (static-only; see PROXY_SAFE_FIELDS)."""
+    import os
+
+    from graftpunk import workstation_env
+    from graftpunk.logging import get_logger
+
+    log = get_logger(__name__)
+    lazy: dict[str, str] = {}
+    command_names = workstation_env.load().command_entry_names()
+    for field_name in GraftpunkSettings.model_fields:
+        env_name = _field_env_name(field_name)
+        if env_name not in command_names:
+            continue
+        if field_name not in PROXY_SAFE_FIELDS:
+            log.warning(
+                "workstation_env_command_unsupported_for_field",
+                envvar=env_name,
+                hint="command values are unsupported for this setting; "
+                "treat as static-only or supply via the real environment",
+            )
+            continue
+        if os.environ.get(env_name):
+            continue  # real env wins; empty string counts as a miss
+        lazy[field_name] = env_name
+    return lazy
+
+
 # Global settings instance
-_settings: GraftpunkSettings | None = None
+_settings: "GraftpunkSettings | LazySettings | None" = None
 
 
-def get_settings() -> GraftpunkSettings:
+def get_settings() -> "GraftpunkSettings | LazySettings":
     """Get or create the global settings instance.
 
-    Returns a singleton instance of GraftpunkSettings, creating it on first call.
-    Subsequent calls return the cached instance. Settings are loaded from
-    environment variables with the GRAFTPUNK_ prefix.
-
-    Returns:
-        The global GraftpunkSettings instance with all configuration loaded
-        from environment variables.
+    First call runs workstation_env.ensure_bootstrap() BEFORE constructing
+    the model — the ordering invariant (file statics precede the singleton)
+    is owned here, structurally, for every entry path: the CLI and
+    in-process library consumers alike. When the workstation file holds
+    command-valued entries for PROXY_SAFE_FIELDS, the singleton is wrapped
+    in a LazySettings proxy; otherwise the raw model is returned unchanged.
     """
     global _settings
     if _settings is None:
-        _settings = GraftpunkSettings()
+        from graftpunk import workstation_env
+
+        workstation_env.ensure_bootstrap()
+        model = GraftpunkSettings()
+        lazy_fields = _build_lazy_field_map()
+        _settings = LazySettings(model, lazy_fields) if lazy_fields else model
     return _settings
 
 

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -237,10 +237,12 @@ def _build_lazy_field_map() -> dict[str, str]:
     log = get_logger(__name__)
     lazy: dict[str, str] = {}
     command_names = workstation_env.load().command_entry_names()
+    matched_env_names: set[str] = set()
     for field_name in GraftpunkSettings.model_fields:
         env_name = _field_env_name(field_name)
         if env_name not in command_names:
             continue
+        matched_env_names.add(env_name)
         if field_name not in PROXY_SAFE_FIELDS:
             log.warning(
                 "workstation_env_command_unsupported_for_field",
@@ -252,6 +254,18 @@ def _build_lazy_field_map() -> dict[str, str]:
         if os.environ.get(env_name):
             continue  # real env wins; empty string counts as a miss
         lazy[field_name] = env_name
+
+    # Typo diagnostic: a command entry that LOOKS like a settings field
+    # (GRAFTPUNK_ prefix) but matches NO model field at all would otherwise
+    # be silently ignored forever — most likely a misspelled setting name.
+    prefix = GraftpunkSettings.model_config.get("env_prefix", "")
+    for env_name in command_names:
+        if env_name.startswith(prefix) and env_name not in matched_env_names:
+            log.warning(
+                "workstation_env_command_unknown_setting",
+                envvar=env_name,
+                hint="no GraftpunkSettings field maps to this name; check for a typo",
+            )
     return lazy
 
 

--- a/src/graftpunk/config.py
+++ b/src/graftpunk/config.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from graftpunk import paths
+
 
 class GraftpunkSettings(BaseSettings):
     """graftpunk application settings loaded from environment variables.
@@ -19,7 +21,10 @@ class GraftpunkSettings(BaseSettings):
         description="Storage backend: local, supabase, s3",
     )
     config_dir: Path = Field(
-        default=Path.home() / ".config" / "graftpunk",
+        # Lambda (not the bare function ref) so the resolver stays
+        # late-bound: tests can monkeypatch paths.config_dir and the
+        # default picks it up.
+        default_factory=lambda: paths.config_dir(),
         description="Configuration directory for graftpunk data",
     )
     session_ttl_hours: int = Field(

--- a/src/graftpunk/paths.py
+++ b/src/graftpunk/paths.py
@@ -1,0 +1,29 @@
+"""Settings-free path resolution shared by config and workstation_env.
+
+This module is the single owner of "where is the config dir". It must stay
+import-light and side-effect-free: no get_settings(), no directory creation
+(GraftpunkSettings.__init__ creates directories; this module must not).
+
+Note: pydantic-settings additionally honors a cwd-relative .env file — a
+GRAFTPUNK_CONFIG_DIR set only there relocates settings.config_dir but does
+NOT relocate the workstation env file. Documented as unsupported.
+"""
+
+import os
+from pathlib import Path
+
+
+def config_dir() -> Path:
+    """Resolve the graftpunk config directory from the real environment.
+
+    GRAFTPUNK_CONFIG_DIR from os.environ, else ~/.config/graftpunk.
+    """
+    override = os.environ.get("GRAFTPUNK_CONFIG_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".config" / "graftpunk"
+
+
+def workstation_env_path() -> Path:
+    """Path of the workstation env file: <config_dir>/env."""
+    return config_dir() / "env"

--- a/src/graftpunk/plugins/yaml_loader.py
+++ b/src/graftpunk/plugins/yaml_loader.py
@@ -8,7 +8,6 @@ YAML plugins are discovered from ~/.config/graftpunk/plugins/*.yaml (and *.yml)
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -124,6 +123,9 @@ class YAMLDiscoveryResult:
 def expand_env_vars(value: str) -> str:
     """Expand ${VAR} patterns in a string with environment variables.
 
+    Resolves variables through workstation env lookup, which checks the
+    environment first, then the workstation env file.
+
     Args:
         value: String potentially containing ${VAR} patterns.
 
@@ -131,12 +133,15 @@ def expand_env_vars(value: str) -> str:
         String with environment variables expanded.
 
     Raises:
-        PluginError: If referenced environment variable is not set.
+        PluginError: if the variable is neither in the environment nor
+            resolvable from the workstation env file.
     """
 
     def replacer(match: re.Match[str]) -> str:
+        from graftpunk import workstation_env
+
         var_name = match.group(1)
-        var_value = os.environ.get(var_name)
+        var_value = workstation_env.load().lookup(var_name)
         if var_value is None:
             raise PluginError(
                 f"Environment variable ${var_name} is not set. Set it before using this plugin."

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -1,0 +1,140 @@
+"""Workstation env file: parse, resolve, and write ~/.config/graftpunk/env.
+
+Single owner of file knowledge AND of the env-beats-file precedence rule
+(see lookup()). Import-light: imports graftpunk.paths, never graftpunk.config
+(config imports this module).
+
+Spec: docs/rfcs/2026-07-28-workstation-env.md
+"""
+
+import os
+import re
+import stat
+import subprocess
+from dataclasses import dataclass
+from typing import Literal
+
+# Importing graftpunk.paths inits the graftpunk package, whose __init__
+# module-level-imports config (and the client stack). No cycle results:
+# config's workstation_env import is function-local (inside get_settings).
+from graftpunk import paths
+from graftpunk.logging import get_logger
+
+LOG = get_logger(__name__)
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_COMMAND_RE = re.compile(r"^\$\((.*)\)$", re.DOTALL)
+
+STATIC = "static"
+COMMAND = "command"
+
+
+@dataclass(frozen=True)
+class Entry:
+    name: str
+    raw_value: str
+    kind: Literal["static", "command"]
+    line_no: int
+    command: str | None = None  # inner text of $(...) for COMMAND entries
+
+
+@dataclass(frozen=True)
+class _Classified:
+    kind: Literal["static", "command"]
+    cleaned: str
+    command: str | None
+    warn_mixed: bool  # static value containing $( that was NOT single-quoted
+
+
+def _classify(value: str) -> _Classified:
+    """Classify a raw value string. The ONLY owner of quote semantics.
+
+    Quote handling runs first: a fully single-quoted value is ALWAYS static
+    (the escape hatch for a literal ``$(``, and never warned about); a fully
+    double-quoted value is unquoted and then command detection proceeds. A
+    value is a command iff the ENTIRE value is one ``$(...)``. Mixed
+    literal+command is static, flagged for a warning (warn_mixed) — the
+    caller decides from this flag, never by re-sniffing quotes.
+    """
+    value = value.strip()
+    if len(value) >= 2 and value[0] == "'" and value[-1] == "'":
+        return _Classified(STATIC, value[1:-1], None, warn_mixed=False)
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        value = value[1:-1]
+    match = _COMMAND_RE.match(value)
+    if match:
+        return _Classified(COMMAND, value, match.group(1), warn_mixed=False)
+    return _Classified(STATIC, value, None, warn_mixed="$(" in value)
+
+
+class WorkstationEnv:
+    def __init__(self, entries: dict[str, Entry]):
+        self._entries = entries
+        self._memo: dict[str, str | None] = {}
+
+    def entries(self) -> list[Entry]:
+        return sorted(self._entries.values(), key=lambda e: e.line_no)
+
+    def get(self, name: str) -> Entry | None:
+        return self._entries.get(name)
+
+
+def _parse(text: str, source: str) -> dict[str, Entry]:
+    entries: dict[str, Entry] = {}
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        name, sep, raw = line.partition("=")
+        name = name.strip()
+        if not sep or not _NAME_RE.match(name):
+            LOG.warning("workstation_env_malformed_line", source=f"{source}:{line_no}")
+            continue
+        classified = _classify(raw)
+        if classified.warn_mixed:
+            LOG.warning(
+                "workstation_env_partial_substitution_unsupported",
+                name=name,
+                source=f"{source}:{line_no}",
+            )
+        entries[name] = Entry(
+            name=name,
+            raw_value=classified.cleaned,
+            kind=classified.kind,
+            line_no=line_no,
+            command=classified.command,
+        )
+    return entries
+
+
+_cached: WorkstationEnv | None = None
+
+
+def load() -> WorkstationEnv:
+    """Parse the workstation env file (absent file -> empty), cached per-process.
+
+    Cache coherence: set_entry()/unset_entry() invalidate this cache, so a
+    write-then-lookup in one process always sees fresh entries.
+    """
+    global _cached
+    if _cached is not None:
+        return _cached
+    path = paths.workstation_env_path()
+    if not path.is_file():
+        _cached = WorkstationEnv({})
+        return _cached
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        LOG.warning(
+            "workstation_env_permissive_mode",
+            path=str(path),
+            mode=oct(mode),
+            hint="expected 0600 file permissions",
+        )
+    _cached = WorkstationEnv(_parse(path.read_text(encoding="utf-8"), str(path)))
+    return _cached
+
+
+def _invalidate_cache() -> None:
+    global _cached
+    _cached = None

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -136,14 +136,23 @@ class WorkstationEnv:
         """THE precedence rule: real env -> file -> None.
 
         A non-empty os.environ value wins (an empty-string value counts as
-        a miss — deliberate, unified across all consumption points).
-        Callers never hand-sequence env-then-file; this is the only
-        implementation of the ordering.
+        a miss — deliberate, unified across all consumption points). The
+        file tier is held to the SAME empty-is-a-miss rule: an empty
+        static (`K=`) or a command that exits 0 with no output also counts
+        as a miss, not a hit of `""` — otherwise a YAML `${VAR}` header
+        would silently render an empty substitution (e.g. `Bearer `)
+        instead of raising the clear "not set" PluginError, and a lazy
+        settings field would silently pick up `""`. Note `resolve_file_value()`
+        itself keeps returning `""` verbatim (`gp config get --resolve`
+        legitimately distinguishes "empty" from "failed"); the miss
+        conversion happens here, in lookup(), alone. Callers never
+        hand-sequence env-then-file; this is the only implementation of
+        the ordering.
         """
         env_value = os.environ.get(name)
         if env_value:
             return env_value
-        return self.resolve_file_value(name)
+        return self.resolve_file_value(name) or None
 
     def command_entry_names(self) -> set[str]:
         return {e.name for e in self._entries.values() if e.kind == COMMAND}

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -255,9 +255,7 @@ def set_entry(name: str, value: str) -> None:
     if not _NAME_RE.match(name):
         raise ValueError(f"invalid variable name: {name!r}")
     path = paths.workstation_env_path()
-    lines = (
-        path.read_text(encoding="utf-8").splitlines(keepends=True) if path.is_file() else []
-    )
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True) if path.is_file() else []
     pattern = _entry_line_pattern(name)
     hits = [i for i, line in enumerate(lines) if pattern.match(line)]
     if len(hits) > 1:

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -13,6 +13,7 @@ import re
 import stat
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 # Importing graftpunk.paths inits the graftpunk package, whose __init__
@@ -69,7 +70,7 @@ def _classify(value: str) -> _Classified:
 
 
 class WorkstationEnv:
-    def __init__(self, entries: dict[str, Entry]):
+    def __init__(self, entries: dict[str, Entry]) -> None:
         self._entries = entries
         self._memo: dict[str, str | None] = {}
         # Companion to _memo, populated only on command failure. Kept
@@ -88,10 +89,11 @@ class WorkstationEnv:
         """FILE-tier resolution only — never consults os.environ.
 
         Statics return their value; commands execute via /bin/sh once per
-        process (results AND failures memoized). This is the single owner
-        of command-execution mechanics, and the public primitive behind
-        `gp config get --resolve` (which deliberately bypasses the env
-        tier: it answers "what does the FILE say").
+        WorkstationEnv instance (results AND failures memoized; a fresh
+        instance — e.g. after _invalidate_cache() — re-runs them). This is
+        the single owner of command-execution mechanics, and the public
+        primitive behind `gp config get --resolve` (which deliberately
+        bypasses the env tier: it answers "what does the FILE say").
         """
         entry = self._entries.get(name)
         if entry is None:
@@ -100,8 +102,18 @@ class WorkstationEnv:
             return entry.raw_value
         if name in self._memo:
             return self._memo[name]
+        command = entry.command
+        if command is None:
+            # Defensive: _classify() only ever produces kind==COMMAND
+            # together with a non-None command string, so this should be
+            # unreachable. Narrows the type for the subprocess.run() call
+            # below and fails loudly (a logged miss) instead of crashing
+            # subprocess.run() on a None argv element if that invariant is
+            # ever violated.
+            LOG.warning("workstation_env_command_entry_missing_command", name=name)
+            return None
         result = subprocess.run(  # noqa: S603
-            ["/bin/sh", "-c", entry.command],
+            ["/bin/sh", "-c", command],
             capture_output=True,
             text=True,
         )
@@ -283,7 +295,7 @@ def ensure_bootstrap() -> None:
     _bootstrapped = True
 
 
-def _atomic_write(path, lines: list[str]) -> None:
+def _atomic_write(path: Path, lines: list[str]) -> None:
     import tempfile
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -7,8 +7,10 @@ Single owner of file knowledge AND of the env-beats-file precedence rule
 Spec: docs/rfcs/2026-07-28-workstation-env.md
 """
 
+import os
 import re
 import stat
+import subprocess
 from dataclasses import dataclass
 from typing import Literal
 
@@ -76,6 +78,70 @@ class WorkstationEnv:
     def get(self, name: str) -> Entry | None:
         return self._entries.get(name)
 
+    def resolve_file_value(self, name: str) -> str | None:
+        """FILE-tier resolution only — never consults os.environ.
+
+        Statics return their value; commands execute via /bin/sh once per
+        process (results AND failures memoized). This is the single owner
+        of command-execution mechanics, and the public primitive behind
+        `gp config get --resolve` (which deliberately bypasses the env
+        tier: it answers "what does the FILE say").
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            return None
+        if entry.kind == STATIC:
+            return entry.raw_value
+        if name in self._memo:
+            return self._memo[name]
+        result = subprocess.run(  # noqa: S603
+            ["/bin/sh", "-c", entry.command],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            LOG.error(
+                "workstation_env_command_failed",
+                name=name,
+                returncode=result.returncode,
+                stderr=result.stderr.strip(),
+            )
+            self._memo[name] = None
+            return None
+        value = result.stdout
+        if value.endswith("\n"):
+            value = value[:-1]
+        self._memo[name] = value
+        return value
+
+    def lookup(self, name: str) -> str | None:
+        """THE precedence rule: real env -> file -> None.
+
+        A non-empty os.environ value wins (an empty-string value counts as
+        a miss — deliberate, unified across all consumption points).
+        Callers never hand-sequence env-then-file; this is the only
+        implementation of the ordering.
+        """
+        env_value = os.environ.get(name)
+        if env_value:
+            return env_value
+        return self.resolve_file_value(name)
+
+    def command_entry_names(self) -> set[str]:
+        return {e.name for e in self._entries.values() if e.kind == COMMAND}
+
+    def inject_static(self) -> None:
+        """Bootstrap: set static entries into os.environ where absent.
+
+        Deliberate asymmetry with lookup(): injection gates on PRESENCE
+        (an operator's explicit empty-string export is respected and never
+        overwritten), while lookup() treats empty-string as a miss (an
+        empty credential is never useful; fall to the file tier).
+        """
+        for entry in self._entries.values():
+            if entry.kind == STATIC and entry.name not in os.environ:
+                os.environ[entry.name] = entry.raw_value
+
 
 def _parse(text: str, source: str) -> dict[str, Entry]:
     entries: dict[str, Entry] = {}
@@ -134,5 +200,24 @@ def load() -> WorkstationEnv:
 
 
 def _invalidate_cache() -> None:
-    global _cached
+    global _cached, _bootstrapped
     _cached = None
+    _bootstrapped = False
+
+
+_bootstrapped = False
+
+
+def ensure_bootstrap() -> None:
+    """Idempotent: parse the file and inject statics, once per process.
+
+    Called by config.get_settings() (before first model construction —
+    which makes the ordering invariant structural for every entry path,
+    CLI and library alike) and by cli/main.py at module scope (only so
+    statics precede the early logging config).
+    """
+    global _bootstrapped
+    if _bootstrapped:
+        return
+    load().inject_static()
+    _bootstrapped = True

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -179,6 +179,19 @@ def _parse(text: str, source: str) -> dict[str, Entry]:
                 name=name,
                 source=f"{source}:{line_no}",
             )
+        if classified.kind == COMMAND and classified.command and ")$(" in classified.command:
+            # _COMMAND_RE's `.*` is greedy and DOTALL, so adjacent
+            # substitutions like $(a)$(b) still match as ONE command whose
+            # inner text is "a)$(b" -- almost certainly not what the
+            # operator meant. The regex stays normative (still classified
+            # as a command, and still executed as such); this warning just
+            # makes the resulting mangled-command failure diagnosable
+            # instead of a silent surprise.
+            LOG.warning(
+                "workstation_env_suspicious_substitution",
+                name=name,
+                source=f"{source}:{line_no}",
+            )
         entries[name] = Entry(
             name=name,
             raw_value=classified.cleaned,
@@ -196,7 +209,19 @@ def load() -> WorkstationEnv:
     """Parse the workstation env file (absent file -> empty), cached per-process.
 
     Cache coherence: set_entry()/unset_entry() invalidate this cache, so a
-    write-then-lookup in one process always sees fresh entries.
+    write-then-resolve of a FILE-tier entry (resolve_file_value(), or
+    lookup() when the real environment doesn't shadow that name) in one
+    process always sees fresh entries. That claim covers the file tier
+    only: inject_static() copies statics into os.environ at bootstrap, and
+    lookup()'s env tier then shadows a same-process rewrite of that same
+    name (os.environ isn't touched by set_entry()/unset_entry()) until the
+    process restarts.
+
+    An unreadable file (permission error) or one that isn't valid UTF-8
+    text degrades the same way as an absent file — a warning is logged and
+    every lookup behaves as if the file were empty — rather than crashing
+    every `gp` invocation, including ones like `gp config path` that need
+    no file access at all.
     """
     global _cached
     if _cached is not None:
@@ -205,15 +230,23 @@ def load() -> WorkstationEnv:
     if not path.is_file():
         _cached = WorkstationEnv({})
         return _cached
-    mode = stat.S_IMODE(path.stat().st_mode)
-    if mode & 0o077:
-        LOG.warning(
-            "workstation_env_permissive_mode",
-            path=str(path),
-            mode=oct(mode),
-            hint="expected 0600 file permissions",
-        )
-    _cached = WorkstationEnv(_parse(path.read_text(encoding="utf-8"), str(path)))
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            LOG.warning(
+                "workstation_env_permissive_mode",
+                path=str(path),
+                mode=oct(mode),
+                hint="expected 0600 file permissions",
+            )
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        # ValueError covers UnicodeDecodeError (a non-UTF-8 file); OSError
+        # covers permission errors and the like.
+        LOG.warning("workstation_env_unreadable", path=str(path), error=str(exc))
+        _cached = WorkstationEnv({})
+        return _cached
+    _cached = WorkstationEnv(_parse(text, str(path)))
     return _cached
 
 
@@ -282,7 +315,14 @@ def set_entry(name: str, value: str) -> None:
     pattern = _entry_line_pattern(name)
     hits = [i for i, line in enumerate(lines) if pattern.match(line)]
     if len(hits) > 1:
-        LOG.warning("workstation_env_duplicate_entries", name=name, count=len(hits))
+        # hits[-1] is the occurrence that gets overwritten below; the rest
+        # are stale duplicates left in the file — name them so the warning
+        # tells the operator exactly which lines to go clean up.
+        LOG.warning(
+            "workstation_env_duplicate_entries",
+            name=name,
+            lines=[h + 1 for h in hits[:-1]],
+        )
     if hits:
         lines[hits[-1]] = f"{name}={value}\n"
     else:

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -7,6 +7,7 @@ Single owner of file knowledge AND of the env-beats-file precedence rule
 Spec: docs/rfcs/2026-07-28-workstation-env.md
 """
 
+import contextlib
 import os
 import re
 import stat
@@ -221,3 +222,83 @@ def ensure_bootstrap() -> None:
         return
     load().inject_static()
     _bootstrapped = True
+
+
+def _atomic_write(path, lines: list[str]) -> None:
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".env-")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("".join(lines))
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+    os.chmod(path, 0o600)
+
+
+def _entry_line_pattern(name: str) -> re.Pattern[str]:
+    return re.compile(rf"^\s*{re.escape(name)}\s*=")
+
+
+def set_entry(name: str, value: str) -> None:
+    """Add or surgically replace NAME=value; preserves every other line.
+
+    Replaces the LAST occurrence when the name is duplicated (read semantics
+    are last-wins), warning about the others. Appends new names at the end.
+    Atomic write (temp + os.replace), 0600 re-asserted.
+    """
+    if not _NAME_RE.match(name):
+        raise ValueError(f"invalid variable name: {name!r}")
+    path = paths.workstation_env_path()
+    lines = (
+        path.read_text(encoding="utf-8").splitlines(keepends=True) if path.is_file() else []
+    )
+    pattern = _entry_line_pattern(name)
+    hits = [i for i, line in enumerate(lines) if pattern.match(line)]
+    if len(hits) > 1:
+        LOG.warning("workstation_env_duplicate_entries", name=name, count=len(hits))
+    if hits:
+        lines[hits[-1]] = f"{name}={value}\n"
+    else:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"{name}={value}\n")
+    _atomic_write(path, lines)
+    _invalidate_cache()
+
+
+def unset_entry(name: str) -> int:
+    """Remove ALL occurrences of NAME (git-config --unset-all semantics).
+
+    Duplicate lines are never intentional; removing only one would silently
+    resurrect an earlier occurrence. Returns the number of lines removed.
+    """
+    path = paths.workstation_env_path()
+    if not path.is_file():
+        return 0
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    pattern = _entry_line_pattern(name)
+    kept = [line for line in lines if not pattern.match(line)]
+    removed = len(lines) - len(kept)
+    if removed > 1:
+        LOG.warning("workstation_env_removed_duplicates", name=name, count=removed)
+    if removed:
+        _atomic_write(path, kept)
+        _invalidate_cache()
+    return removed
+
+
+def ensure_file() -> None:
+    """Create the workstation env file (empty, 0600, parents) if absent.
+
+    The public create-if-absent operation — callers (e.g. `gp config edit`)
+    must never reach for the private _atomic_write.
+    """
+    path = paths.workstation_env_path()
+    if not path.is_file():
+        _atomic_write(path, [])

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -7,10 +7,8 @@ Single owner of file knowledge AND of the env-beats-file precedence rule
 Spec: docs/rfcs/2026-07-28-workstation-env.md
 """
 
-import os
 import re
 import stat
-import subprocess
 from dataclasses import dataclass
 from typing import Literal
 

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -72,6 +72,11 @@ class WorkstationEnv:
     def __init__(self, entries: dict[str, Entry]):
         self._entries = entries
         self._memo: dict[str, str | None] = {}
+        # Companion to _memo, populated only on command failure. Kept
+        # private/separate rather than folded into _memo's value type so
+        # lookup()'s public contract (Optional[str]) never changes; only
+        # last_resolve_error() (the CLI's --resolve path) reads it.
+        self._memo_stderr: dict[str, str] = {}
 
     def entries(self) -> list[Entry]:
         return sorted(self._entries.values(), key=lambda e: e.line_no)
@@ -101,19 +106,31 @@ class WorkstationEnv:
             text=True,
         )
         if result.returncode != 0:
+            stderr = result.stderr.strip()
             LOG.error(
                 "workstation_env_command_failed",
                 name=name,
                 returncode=result.returncode,
-                stderr=result.stderr.strip(),
+                stderr=stderr,
             )
             self._memo[name] = None
+            self._memo_stderr[name] = stderr
             return None
         value = result.stdout
         if value.endswith("\n"):
             value = value[:-1]
         self._memo[name] = value
         return value
+
+    def last_resolve_error(self, name: str) -> str | None:
+        """Stderr text from NAME's most recent failed command resolution.
+
+        None if NAME has never failed (or hasn't been resolved yet). A
+        narrow companion to resolve_file_value()'s memoized None, for the
+        CLI's `--resolve` path (get_cmd) to show the user WHY a command
+        failed — lookup()'s own contract stays a plain Optional[str].
+        """
+        return self._memo_stderr.get(name)
 
     def lookup(self, name: str) -> str | None:
         """THE precedence rule: real env -> file -> None.

--- a/src/graftpunk/workstation_env.py
+++ b/src/graftpunk/workstation_env.py
@@ -254,6 +254,12 @@ def set_entry(name: str, value: str) -> None:
     """
     if not _NAME_RE.match(name):
         raise ValueError(f"invalid variable name: {name!r}")
+    if "\n" in value or "\r" in value:
+        # A newline in value would let a single set_entry() call inject a
+        # second, attacker-controlled NAME=value line (e.g.
+        # K=$'x\nEVIL=1') into the file we otherwise write one line at a
+        # time.
+        raise ValueError(f"value for {name!r} must not contain newlines")
     path = paths.workstation_env_path()
     lines = path.read_text(encoding="utf-8").splitlines(keepends=True) if path.is_file() else []
     pattern = _entry_line_pattern(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Pytest configuration for graftpunk tests."""
 
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,27 @@ from structlog._config import BoundLoggerLazyProxy
 src_dir = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_dir))
 
+# MODULE SCOPE, not a fixture: this root conftest.py is imported before ANY
+# test module, at collection time — before per-test fixtures ever run.
+# graftpunk.cli.main runs workstation_env.ensure_bootstrap() at ITS module
+# scope too, so merely collecting a test module that imports (directly or
+# transitively) graftpunk.cli.main triggers bootstrap against whatever
+# GRAFTPUNK_CONFIG_DIR is live in the real process environment — which, on a
+# developer machine with a populated ~/.config/graftpunk/env, means real
+# statics (e.g. GRAFTPUNK_BROWSER_EXECUTABLE_PATH) get injected into
+# os.environ. ensure_bootstrap()/inject_static() are idempotent-once-per-
+# process, so that leak is permanent for the rest of the pytest run and
+# contaminates unrelated tests (isolated_config's per-test monkeypatch runs
+# far too late to prevent it). Point GRAFTPUNK_CONFIG_DIR at a fresh, empty
+# temp directory (no `env` file in it) before collection can import anything,
+# so collection-time bootstrap reads an absent file instead of the real one.
+# setdefault (not setenv) so an operator/CI override of GRAFTPUNK_CONFIG_DIR
+# still wins.
+os.environ.setdefault(
+    "GRAFTPUNK_CONFIG_DIR",
+    tempfile.mkdtemp(prefix="graftpunk-test-config-"),
+)
+
 
 @pytest.fixture(autouse=True)
 def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -20,6 +43,9 @@ def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     - Creates a temporary config directory for each test
     - Sets GRAFTPUNK_CONFIG_DIR to the temp directory
     - Resets the global settings instance before each test
+    - Invalidates workstation_env's process-global cache/bootstrap flag so
+      load() re-reads from THIS test's config dir instead of whatever was
+      cached under a previous config dir (collection-time or another test's)
     """
     config_dir = tmp_path / "graftpunk"
     config_dir.mkdir(parents=True, exist_ok=True)
@@ -27,12 +53,19 @@ def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Set environment variable for config directory
     monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(config_dir))
 
-    # Reset global settings to pick up new config
+    from graftpunk import workstation_env
     from graftpunk.config import reset_settings
 
+    # Reset global settings to pick up new config
     reset_settings()
+    # Retire the per-file autouse _invalidate_cache() fixtures' reason for
+    # existing: this single call, at this single seam, makes every test see
+    # its own config_dir's workstation env file (or lack of one).
+    workstation_env._invalidate_cache()
 
-    return config_dir
+    yield config_dir
+
+    workstation_env._invalidate_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -577,7 +577,7 @@ class TestPluginsCommand:
 class TestConfigCommand:
     """Tests for config command."""
 
-    @patch("graftpunk.cli.main.get_settings")
+    @patch("graftpunk.cli.config_commands.get_settings")
     def test_config_command(self, mock_settings):
         """Test config command output."""
         mock_settings.return_value = MagicMock(
@@ -595,7 +595,7 @@ class TestConfigCommand:
         assert "local" in result.output
         assert "filesystem" in result.output
 
-    @patch("graftpunk.cli.main.get_settings")
+    @patch("graftpunk.cli.config_commands.get_settings")
     def test_config_supabase_storage(self, mock_settings):
         """Test config command with supabase storage backend."""
         mock_settings.return_value = MagicMock(

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -111,3 +111,18 @@ def test_edit_uses_visual_then_editor(monkeypatch, _isolated):
     monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
     runner.invoke(app, ["config", "edit"])
     assert calls and calls[0][0] == "visual-editor"
+
+
+def test_edit_reasserts_0600_after_editor_exits(monkeypatch, _isolated):
+    # Simulate an editor that writes via replace-on-save, leaving the file
+    # at the process umask's permissions (e.g. 0644) rather than 0600.
+    def fake_editor_call(argv):
+        (_isolated / "env").chmod(0o644)
+        return 0
+
+    monkeypatch.setenv("EDITOR", "some-editor")
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.setattr("subprocess.call", fake_editor_call)
+    result = runner.invoke(app, ["config", "edit"])
+    assert result.exit_code == 0
+    assert stat.S_IMODE((_isolated / "env").stat().st_mode) == 0o600

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -105,6 +105,13 @@ def test_get_resolve_failed_command_exits_1(_isolated):
     assert result.exit_code == 1
 
 
+def test_get_resolve_failed_command_surfaces_stderr(_isolated):
+    runner.invoke(app, ["config", "set", "K", "$(echo custom-error-message 1>&2; exit 3)"])
+    result = runner.invoke(app, ["config", "get", "K", "--resolve"])
+    assert result.exit_code == 1
+    assert "custom-error-message" in (result.stderr or "")
+
+
 def test_edit_uses_visual_then_editor(monkeypatch, _isolated):
     calls = []
     monkeypatch.setenv("VISUAL", "visual-editor")

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -112,13 +112,65 @@ def test_get_resolve_failed_command_surfaces_stderr(_isolated):
     assert "custom-error-message" in (result.stderr or "")
 
 
-def test_edit_uses_visual_then_editor(monkeypatch, _isolated):
+def test_get_resolve_failed_command_stderr_survives_rich_markup(_isolated):
+    # Reviewer finding: interpolating foreign stderr into a "[red]...[/red]"
+    # markup string ate "[flags]"-style tokens (and raised MarkupError on
+    # unbalanced "[/...]" tokens). markup=False must let it through verbatim.
+    runner.invoke(app, ["config", "set", "K", "$(echo '[flags] boom' 1>&2; exit 3)"])
+    result = runner.invoke(app, ["config", "get", "K", "--resolve"])
+    assert result.exit_code == 1
+    assert "[flags] boom" in (result.stderr or "")
+
+
+def test_edit_uses_visual_over_editor_when_both_set(monkeypatch, _isolated):
     calls = []
     monkeypatch.setenv("VISUAL", "visual-editor")
     monkeypatch.setenv("EDITOR", "other-editor")
     monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
-    runner.invoke(app, ["config", "edit"])
-    assert calls and calls[0][0] == "visual-editor"
+    result = runner.invoke(app, ["config", "edit"])
+    assert result.exit_code == 0
+    assert calls == [["visual-editor", str(_isolated / "env")]]
+
+
+def test_edit_uses_editor_when_visual_unset(monkeypatch, _isolated):
+    # Reviewer finding (A2/B1): a multi-word $EDITOR like "code --wait" was
+    # exec'd as one literal binary name (FileNotFoundError). shlex.split
+    # must break it into ["code", "--wait", path].
+    calls = []
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.setenv("EDITOR", "code --wait")
+    monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
+    result = runner.invoke(app, ["config", "edit"])
+    assert result.exit_code == 0
+    assert calls == [["code", "--wait", str(_isolated / "env")]]
+
+
+def test_edit_defaults_to_vi_when_neither_set(monkeypatch, _isolated):
+    calls = []
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+    monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
+    result = runner.invoke(app, ["config", "edit"])
+    assert result.exit_code == 0
+    assert calls == [["vi", str(_isolated / "env")]]
+
+
+def test_edit_missing_editor_binary_exits_1_with_message(monkeypatch, _isolated):
+    # Reviewer finding (A2/B1): subprocess.call raises FileNotFoundError
+    # (rather than returning a nonzero exit code) when the editor binary
+    # doesn't exist -- edit_cmd must turn that into a clean CLI error, not
+    # an uncaught traceback.
+    monkeypatch.setenv("EDITOR", "definitely-not-a-real-editor-binary")
+    monkeypatch.delenv("VISUAL", raising=False)
+
+    def _raise(argv):
+        raise FileNotFoundError(2, "No such file or directory", argv[0])
+
+    monkeypatch.setattr("subprocess.call", _raise)
+    result = runner.invoke(app, ["config", "edit"])
+    assert result.exit_code == 1
+    assert result.stderr
+    assert not isinstance(result.exception, FileNotFoundError)
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
@@ -162,3 +214,36 @@ def test_edit_reasserts_0600_after_editor_exits(monkeypatch, _isolated):
     result = runner.invoke(app, ["config", "edit"])
     assert result.exit_code == 0
     assert stat.S_IMODE((_isolated / "env").stat().st_mode) == 0o600
+
+
+def test_unset_non_utf8_file_exits_1_clean(_isolated):
+    # Reviewer finding (A6): unset_entry() reads the file directly (unlike
+    # load(), which already degrades a non-UTF-8 file to "empty"), so
+    # unset_cmd must catch ValueError (UnicodeDecodeError) too, not just
+    # OSError -- otherwise this is an uncaught traceback.
+    (_isolated / "env").write_bytes(b"K=\xff\xfevalue\n")
+    result = runner.invoke(app, ["config", "unset", "K"])
+    assert result.exit_code == 1
+    assert result.stderr
+    assert not isinstance(result.exception, UnicodeDecodeError)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_config_path_survives_unreadable_env_file(_isolated):
+    # Reviewer finding (A1): load() (run via ensure_bootstrap() in
+    # main_callback for EVERY command) used to let stat()/read_text()
+    # crash the whole CLI on an unreadable file -- including `gp config
+    # path`, which needs no file access at all. (The stdout-stays-clean /
+    # warning-goes-to-stderr half of this claim is covered by a spawned-
+    # process test in test_workstation_env_lifecycle.py, matching how
+    # test_bootstrap_warning_goes_to_stderr_not_stdout there already
+    # covers the analogous permissive-mode warning -- CliRunner captures
+    # stdout/stderr in a way that doesn't reflect real structlog routing.)
+    (_isolated / "env").write_text("K=v\n")
+    (_isolated / "env").chmod(0o000)
+    try:
+        result = runner.invoke(app, ["config", "path"])
+    finally:
+        (_isolated / "env").chmod(0o600)
+    assert result.exit_code == 0
+    assert str(_isolated / "env") in result.stdout

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -1,0 +1,113 @@
+"""gp config command family (spec § gp config command family)."""
+
+import stat
+
+import pytest
+from typer.testing import CliRunner
+
+from graftpunk import workstation_env
+from graftpunk.cli.main import app
+
+# Plain CliRunner: click 8.2+ removed mix_stderr — stderr is always captured
+# separately and result.stderr works (verified against the venv's typer 0.21.1
+# / click 8.3.1; passing mix_stderr raises TypeError at collection).
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+    workstation_env._invalidate_cache()
+    yield tmp_path
+    workstation_env._invalidate_cache()
+
+
+# Every field label the old panel rendered — the migration constraint is
+# "unchanged behavior", so the test asserts the full label set, not one word.
+_PANEL_LABELS = (
+    "Config directory:",
+    "Sessions directory:",
+    "Storage backend:",
+    "Session TTL:",
+    "Log level:",
+    "Log format:",
+)
+
+
+def test_bare_config_renders_settings_panel(_isolated):
+    result = runner.invoke(app, ["config"])
+    assert result.exit_code == 0
+    assert "Configuration" in result.stdout
+    for label in _PANEL_LABELS:
+        assert label in result.stdout  # migrated display, unchanged behavior
+
+
+def test_config_show_same_panel(_isolated):
+    result = runner.invoke(app, ["config", "show"])
+    assert result.exit_code == 0
+    for label in _PANEL_LABELS:
+        assert label in result.stdout
+
+
+def test_config_path(_isolated):
+    result = runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(_isolated / "env")
+
+
+def test_set_get_list_unset_roundtrip(_isolated):
+    assert (
+        runner.invoke(app, ["config", "set", "SHOPKEEP_STORE_NAME", "the-french-co"]).exit_code == 0
+    )
+    got = runner.invoke(app, ["config", "get", "SHOPKEEP_STORE_NAME"])
+    assert got.stdout.strip() == "the-french-co"
+    listed = runner.invoke(app, ["config", "list"])
+    assert "SHOPKEEP_STORE_NAME=the-french-co" in listed.stdout
+    assert runner.invoke(app, ["config", "unset", "SHOPKEEP_STORE_NAME"]).exit_code == 0
+    assert runner.invoke(app, ["config", "get", "SHOPKEEP_STORE_NAME"]).exit_code == 1
+
+
+def test_set_stores_command_verbatim_and_get_resolve_evaluates(_isolated):
+    runner.invoke(app, ["config", "set", "K", "$(echo hi)"])
+    raw = runner.invoke(app, ["config", "get", "K"])
+    assert raw.stdout.strip() == "$(echo hi)"
+    resolved = runner.invoke(app, ["config", "get", "K", "--resolve"])
+    assert resolved.stdout.strip() == "hi"
+    listed = runner.invoke(app, ["config", "list"])
+    assert "K=$(echo hi)  [command]" in listed.stdout  # list surfaces the kind
+
+
+def test_set_secret_literal_guardrail_warns(_isolated):
+    result = runner.invoke(app, ["config", "set", "BEK_PASSWORD", "plaintext-oops"])
+    assert result.exit_code == 0  # warn, don't refuse
+    assert (
+        "warning" in (result.stderr or "").lower() or "plaintext" in (result.stderr or "").lower()
+    )
+
+
+def test_set_bad_name_fails(_isolated):
+    assert runner.invoke(app, ["config", "set", "9BAD", "v"]).exit_code != 0
+
+
+def test_unset_absent_is_idempotent(_isolated):
+    assert runner.invoke(app, ["config", "unset", "NEVER_SET"]).exit_code == 0
+
+
+def test_file_mode_after_cli_write(_isolated):
+    runner.invoke(app, ["config", "set", "K", "v"])
+    assert stat.S_IMODE((_isolated / "env").stat().st_mode) == 0o600
+
+
+def test_get_resolve_failed_command_exits_1(_isolated):
+    runner.invoke(app, ["config", "set", "K", "$(exit 7)"])
+    result = runner.invoke(app, ["config", "get", "K", "--resolve"])
+    assert result.exit_code == 1
+
+
+def test_edit_uses_visual_then_editor(monkeypatch, _isolated):
+    calls = []
+    monkeypatch.setenv("VISUAL", "visual-editor")
+    monkeypatch.setenv("EDITOR", "other-editor")
+    monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
+    runner.invoke(app, ["config", "edit"])
+    assert calls and calls[0][0] == "visual-editor"

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -1,5 +1,6 @@
 """gp config command family (spec § gp config command family)."""
 
+import os
 import stat
 
 import pytest
@@ -111,6 +112,34 @@ def test_edit_uses_visual_then_editor(monkeypatch, _isolated):
     monkeypatch.setattr("subprocess.call", lambda argv: calls.append(argv) or 0)
     runner.invoke(app, ["config", "edit"])
     assert calls and calls[0][0] == "visual-editor"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_set_unwritable_config_dir_exits_1_with_message(_isolated):
+    # Prime settings construction (creates config_dir/sessions) while the
+    # directory is still writable, so the read-only chmod below exercises
+    # set_entry()'s own write failure rather than an unrelated PermissionError
+    # from GraftpunkSettings.__init__'s directory creation in main_callback.
+    runner.invoke(app, ["config", "path"])
+    _isolated.chmod(0o500)
+    try:
+        result = runner.invoke(app, ["config", "set", "K", "v"])
+        assert result.exit_code == 1
+        assert result.stderr
+    finally:
+        _isolated.chmod(0o700)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_unset_unwritable_config_dir_exits_1_with_message(_isolated):
+    runner.invoke(app, ["config", "set", "K", "v"])
+    _isolated.chmod(0o500)
+    try:
+        result = runner.invoke(app, ["config", "unset", "K"])
+        assert result.exit_code == 1
+        assert result.stderr
+    finally:
+        _isolated.chmod(0o700)
 
 
 def test_edit_reasserts_0600_after_editor_exits(monkeypatch, _isolated):

--- a/tests/unit/test_lazy_settings.py
+++ b/tests/unit/test_lazy_settings.py
@@ -114,6 +114,20 @@ def test_failed_command_falls_back_to_default(_fresh):
     assert any(e["event"] == "workstation_env_command_failed" for e in cap)
 
 
+def test_unknown_graftpunk_command_entry_warns_typo(_fresh):
+    # GRAFTPUNK_ prefix but no matching model field at all -- most likely a
+    # misspelled setting name (e.g. BROWSER misspelled), otherwise silently
+    # ignored forever.
+    _write_env(_fresh, "GRAFTPUNK_BROWSR_EXECUTABLE_PATH=$(echo /typo/chrome)\n")
+    with capture_logs() as cap:
+        gp_config.get_settings()
+    assert any(
+        e["event"] == "workstation_env_command_unknown_setting"
+        and e.get("envvar") == "GRAFTPUNK_BROWSR_EXECUTABLE_PATH"
+        for e in cap
+    )
+
+
 def test_proxy_delegates_methods_to_model(_fresh):
     _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /lazy/chrome)\n")
     settings = gp_config.get_settings()

--- a/tests/unit/test_lazy_settings.py
+++ b/tests/unit/test_lazy_settings.py
@@ -1,0 +1,122 @@
+"""Lazy settings proxy: bounded allowlist, source-aware precedence.
+
+Spec: § Consumption point (b).
+"""
+
+import os
+import subprocess
+
+import pytest
+from structlog.testing import capture_logs
+
+from graftpunk import config as gp_config
+from graftpunk import workstation_env
+
+
+@pytest.fixture(autouse=True)
+def _fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", raising=False)
+    workstation_env._invalidate_cache()
+    gp_config.reset_settings()
+    yield tmp_path
+    workstation_env._invalidate_cache()
+    gp_config.reset_settings()
+    # inject_static() (exercised by the static-entry tests below) writes
+    # straight into os.environ, bypassing monkeypatch bookkeeping — and
+    # monkeypatch.delenv(..., raising=False) above registers no undo when
+    # the var was already absent (pytest only records undo for keys that
+    # existed at delenv-time). Without this, a leaked
+    # GRAFTPUNK_BROWSER_EXECUTABLE_PATH survives into later, unrelated
+    # tests in the same worker process. Scrub explicitly rather than rely
+    # on monkeypatch here.
+    os.environ.pop("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", None)
+
+
+def _write_env(tmp_path, content):
+    (tmp_path / "env").write_text(content, encoding="utf-8")
+
+
+def test_static_visible_via_bootstrap(_fresh):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/file/chrome\n")
+    settings = gp_config.get_settings()
+    assert settings.browser_executable_path == "/file/chrome"
+
+
+def test_no_command_entries_returns_raw_model(_fresh):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/file/chrome\n")
+    settings = gp_config.get_settings()
+    assert isinstance(settings, gp_config.GraftpunkSettings)  # not a proxy
+
+
+def test_command_value_not_evaluated_at_get_settings(_fresh, monkeypatch):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /lazy/chrome)\n")
+
+    def boom(*a, **kw):
+        raise AssertionError("evaluated too early")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    gp_config.get_settings()  # construction must not evaluate
+
+
+def test_command_value_resolves_on_first_access_once(_fresh, monkeypatch):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /lazy/chrome)\n")
+    settings = gp_config.get_settings()
+    calls = []
+    real_run = subprocess.run
+
+    def counting_run(*a, **kw):
+        calls.append(a)
+        return real_run(*a, **kw)
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+    assert settings.browser_executable_path == "/lazy/chrome"
+    assert settings.browser_executable_path == "/lazy/chrome"
+    assert len(calls) == 1
+
+
+def test_real_env_beats_command_value(_fresh, monkeypatch):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /file/chrome)\n")
+    monkeypatch.setenv("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", "/env/chrome")
+    settings = gp_config.get_settings()
+    assert settings.browser_executable_path == "/env/chrome"
+
+
+def test_dotenv_provided_field_yields_to_command_value(_fresh, monkeypatch, tmp_path):
+    # Source-aware gate: cwd .env is BELOW the workstation file for both
+    # value kinds (documented precedence).
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /file/chrome)\n")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".env").write_text("GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/dotenv/chrome\n")
+    monkeypatch.chdir(project)
+    settings = gp_config.get_settings()
+    assert settings.browser_executable_path == "/file/chrome"
+
+
+def test_non_allowlisted_command_warns_and_is_ignored(_fresh):
+    _write_env(_fresh, "GRAFTPUNK_SUPABASE_URL=$(echo https://x)\n")
+    with capture_logs() as cap:
+        settings = gp_config.get_settings()
+    assert settings.supabase_url is None  # overlay never applies
+    assert any(
+        e["event"] == "workstation_env_command_unsupported_for_field"
+        and e.get("envvar") == "GRAFTPUNK_SUPABASE_URL"
+        for e in cap
+    )
+
+
+def test_failed_command_falls_back_to_default(_fresh):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(exit 5)\n")
+    settings = gp_config.get_settings()
+    with capture_logs() as cap:
+        assert settings.browser_executable_path is None
+    assert any(e["event"] == "workstation_env_command_failed" for e in cap)
+
+
+def test_proxy_delegates_methods_to_model(_fresh):
+    _write_env(_fresh, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(echo /lazy/chrome)\n")
+    settings = gp_config.get_settings()
+    # Model-internal reads bind to the raw model (bounded contract) — the
+    # local storage config still works through the proxy.
+    assert settings.get_storage_config()["base_dir"] == settings.sessions_dir

--- a/tests/unit/test_login_workstation_env.py
+++ b/tests/unit/test_login_workstation_env.py
@@ -1,0 +1,85 @@
+"""Credential resolution: env -> workstation file -> prompt (spec § point (a))."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from graftpunk import workstation_env
+from graftpunk.cli.login_commands import make_login_body
+
+
+@pytest.fixture(autouse=True)
+def _fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+    workstation_env._invalidate_cache()
+    yield tmp_path
+    workstation_env._invalidate_cache()
+
+
+def _plugin(site="acme", **attrs):
+    return SimpleNamespace(site_name=site, **attrs)
+
+
+def test_file_static_used_when_env_missing(_fresh, monkeypatch):
+    (_fresh / "env").write_text("ACME_USERNAME=filed-user\nACME_PASSWORD=filed-pass\n")
+    monkeypatch.delenv("ACME_USERNAME", raising=False)
+    monkeypatch.delenv("ACME_PASSWORD", raising=False)
+    captured = {}
+
+    def login(credentials):
+        captured.update(credentials)
+        return True
+
+    body = make_login_body(_plugin(), login, {"username": "#u", "password": "#p"})
+    body(SimpleNamespace())
+    assert captured == {"username": "filed-user", "password": "filed-pass"}
+
+
+def test_env_beats_file(_fresh, monkeypatch):
+    (_fresh / "env").write_text("ACME_USERNAME=filed-user\nACME_PASSWORD=filed-pass\n")
+    monkeypatch.setenv("ACME_USERNAME", "env-user")
+    monkeypatch.setenv("ACME_PASSWORD", "env-pass")
+    captured = {}
+
+    def login(credentials):
+        captured.update(credentials)
+        return True
+
+    body = make_login_body(_plugin(), login, {"username": "#u", "password": "#p"})
+    body(SimpleNamespace())
+    assert captured["username"] == "env-user"
+
+
+def test_command_failure_falls_through_to_prompt(_fresh, monkeypatch):
+    (_fresh / "env").write_text("ACME_PASSWORD=$(exit 9)\n")
+    monkeypatch.delenv("ACME_PASSWORD", raising=False)
+    monkeypatch.setenv("ACME_USERNAME", "env-user")
+    captured = {}
+
+    def login(credentials):
+        captured.update(credentials)
+        return True
+
+    body = make_login_body(_plugin(), login, {"username": "#u", "password": "#p"})
+    with patch.object(typer, "prompt", return_value="typed-pass") as prompt:
+        body(SimpleNamespace())
+    assert captured["password"] == "typed-pass"  # noqa: S105
+    prompt.assert_called_once()
+
+
+def test_envvar_override_resolves_from_file(_fresh, monkeypatch):
+    (_fresh / "env").write_text("CUSTOM_USER_VAR=overridden-user\nACME_PASSWORD=pw\n")
+    monkeypatch.delenv("CUSTOM_USER_VAR", raising=False)
+    monkeypatch.delenv("ACME_PASSWORD", raising=False)
+    captured = {}
+
+    def login(credentials):
+        captured.update(credentials)
+        return True
+
+    plugin = _plugin(username_envvar="CUSTOM_USER_VAR")
+    body = make_login_body(plugin, login, {"username": "#u", "password": "#p"})
+    body(SimpleNamespace())
+    assert captured["username"] == "overridden-user"

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,44 @@
+"""Tests for graftpunk.paths — settings-free path resolution."""
+
+from pathlib import Path
+
+from graftpunk import paths
+
+
+def test_config_dir_defaults_to_home_config(monkeypatch):
+    monkeypatch.delenv("GRAFTPUNK_CONFIG_DIR", raising=False)
+    assert paths.config_dir() == Path.home() / ".config" / "graftpunk"
+
+
+def test_config_dir_honors_real_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path / "custom"))
+    assert paths.config_dir() == tmp_path / "custom"
+
+
+def test_config_dir_creates_no_directories(monkeypatch, tmp_path):
+    # Settings-free AND side-effect-free: resolving must not mkdir
+    # (GraftpunkSettings.__init__ creates dirs; this helper must not).
+    target = tmp_path / "never-created"
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(target))
+    paths.config_dir()
+    paths.workstation_env_path()
+    assert not target.exists()
+
+
+def test_workstation_env_path_is_env_under_config_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+    assert paths.workstation_env_path() == tmp_path / "env"
+
+
+def test_pydantic_config_dir_default_routes_through_paths(monkeypatch, tmp_path):
+    # Single owner: the settings field default and paths.config_dir() can
+    # never diverge because the former calls the latter. Delete the env var
+    # (else pydantic's env source supplies the field and the default never
+    # runs) and monkeypatch the resolver to prove the DEFAULT routes
+    # through it.
+    monkeypatch.delenv("GRAFTPUNK_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(paths, "config_dir", lambda: tmp_path / "routed")
+    from graftpunk.config import GraftpunkSettings
+
+    settings = GraftpunkSettings(_env_file=None)
+    assert settings.config_dir == tmp_path / "routed"

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -1,0 +1,95 @@
+"""Tests for graftpunk.workstation_env (spec: docs/rfcs/2026-07-28-workstation-env.md)."""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from structlog.testing import capture_logs
+
+from graftpunk import workstation_env
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    workstation_env._invalidate_cache()
+    yield
+    workstation_env._invalidate_cache()
+
+
+@pytest.fixture()
+def env_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+    return tmp_path / "env"
+
+
+def _write(env_file: Path, content: str) -> None:
+    env_file.write_text(content, encoding="utf-8")
+
+
+class TestParser:
+    def test_static_value_verbatim(self, env_file):
+        _write(env_file, "SHOPKEEP_STORE_NAME=the-french-co\n")
+        entry = workstation_env.load().get("SHOPKEEP_STORE_NAME")
+        assert entry.kind == "static"
+        assert entry.raw_value == "the-french-co"
+
+    def test_whole_value_command_substitution(self, env_file):
+        _write(env_file, 'SHOPKEEP_PASSWORD=$(op read "op://v/i/password")\n')
+        entry = workstation_env.load().get("SHOPKEEP_PASSWORD")
+        assert entry.kind == "command"
+        assert entry.command == 'op read "op://v/i/password"'
+
+    def test_single_quoted_is_always_static(self, env_file):
+        # The escape hatch for a literal $( — single quotes suppress detection.
+        _write(env_file, "WEIRD='$(not a command)'\n")
+        entry = workstation_env.load().get("WEIRD")
+        assert entry.kind == "static"
+        assert entry.raw_value == "$(not a command)"
+
+    def test_double_quoted_command_detected(self, env_file):
+        _write(env_file, 'K="$(echo hi)"\n')
+        assert workstation_env.load().get("K").kind == "command"
+
+    def test_mixed_literal_and_command_is_static_with_warning(self, env_file):
+        _write(env_file, "MIXED=pre$(echo x)post\n")
+        with capture_logs() as cap:
+            entry = workstation_env.load().get("MIXED")
+        assert entry.kind == "static"
+        assert entry.raw_value == "pre$(echo x)post"
+        assert any(
+            e["event"] == "workstation_env_partial_substitution_unsupported"
+            and e.get("name") == "MIXED"
+            for e in cap
+        )
+
+    def test_inline_hash_is_not_a_comment(self, env_file):
+        _write(env_file, "K=value#notcomment\n")
+        assert workstation_env.load().get("K").raw_value == "value#notcomment"
+
+    def test_comments_and_blank_lines_skipped(self, env_file):
+        _write(env_file, "# a comment\n\n  # indented comment\nK=v\n")
+        entries = workstation_env.load().entries()
+        assert [e.name for e in entries] == ["K"]
+
+    def test_malformed_line_warns_and_skips(self, env_file):
+        _write(env_file, "NO_EQUALS_HERE\n9BAD=name\nGOOD=1\n")
+        with capture_logs() as cap:
+            entries = workstation_env.load().entries()
+        assert [e.name for e in entries] == ["GOOD"]
+        assert any(e["event"] == "workstation_env_malformed_line" for e in cap)
+
+    def test_duplicate_name_last_wins(self, env_file):
+        _write(env_file, "K=first\nK=second\n")
+        assert workstation_env.load().get("K").raw_value == "second"
+
+    def test_absent_file_is_empty(self, env_file):
+        assert workstation_env.load().entries() == []
+
+    def test_world_readable_file_warns(self, env_file):
+        _write(env_file, "K=v\n")
+        os.chmod(env_file, 0o644)
+        with capture_logs() as cap:
+            workstation_env.load()
+        assert any(e["event"] == "workstation_env_permissive_mode" for e in cap)

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -1,6 +1,7 @@
 """Tests for graftpunk.workstation_env (spec: docs/rfcs/2026-07-28-workstation-env.md)."""
 
 import os
+import stat
 import subprocess
 from pathlib import Path
 
@@ -192,3 +193,57 @@ class TestBootstrap:
         os.environ["INJ_D"] = "changed"
         workstation_env.ensure_bootstrap()  # second call must not re-inject
         assert os.environ["INJ_D"] == "changed"
+
+
+class TestWriter:
+    def test_set_appends_new_name_and_chmods(self, env_file):
+        workstation_env.set_entry("NEW", "val")
+        assert "NEW=val" in env_file.read_text().splitlines()
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+
+    def test_set_preserves_comments_and_order(self, env_file):
+        _write(env_file, "# header comment\nA=1\n\n# about B\nB=2\n")
+        workstation_env.set_entry("B", "3")
+        assert env_file.read_text() == "# header comment\nA=1\n\n# about B\nB=3\n"
+
+    def test_set_replaces_last_duplicate_and_warns(self, env_file):
+        _write(env_file, "K=first\nK=second\n")
+        with capture_logs() as cap:
+            workstation_env.set_entry("K", "third")
+        lines = env_file.read_text().splitlines()
+        assert lines == ["K=first", "K=third"]
+        assert any(e["event"] == "workstation_env_duplicate_entries" for e in cap)
+
+    def test_set_creates_parent_dir_and_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path / "deep" / "cfg"))
+        workstation_env._invalidate_cache()
+        workstation_env.set_entry("K", "v")
+        target = tmp_path / "deep" / "cfg" / "env"
+        assert target.read_text() == "K=v\n"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_unset_removes_all_occurrences(self, env_file):
+        _write(env_file, "K=a\nOTHER=x\nK=b\n")
+        removed = workstation_env.unset_entry("K")
+        assert removed == 2
+        assert env_file.read_text() == "OTHER=x\n"
+
+    def test_unset_absent_is_zero_and_ok(self, env_file):
+        _write(env_file, "A=1\n")
+        assert workstation_env.unset_entry("MISSING") == 0
+
+    def test_write_then_lookup_sees_fresh_value(self, env_file, monkeypatch):
+        # Cache coherence contract: writers invalidate the load() cache.
+        _write(env_file, "K=old\n")
+        monkeypatch.delenv("K", raising=False)
+        assert workstation_env.load().lookup("K") == "old"
+        workstation_env.set_entry("K", "new")
+        assert workstation_env.load().lookup("K") == "new"
+
+    def test_ensure_file_creates_empty_0600_and_is_idempotent(self, env_file):
+        workstation_env.ensure_file()
+        assert env_file.read_text() == ""
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+        _write(env_file, "K=v\n")
+        workstation_env.ensure_file()  # must not truncate an existing file
+        assert env_file.read_text() == "K=v\n"

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -196,6 +196,14 @@ class TestBootstrap:
 
 
 class TestWriter:
+    @pytest.mark.parametrize("bad_value", ["x\nEVIL=1", "x\r\nEVIL=1", "trailing\r"])
+    def test_set_rejects_embedded_newline(self, env_file, bad_value):
+        # A newline in the value would let one set_entry() call smuggle a
+        # second NAME=value line into the file (e.g. K=$'x\nEVIL=1').
+        with pytest.raises(ValueError, match="newline"):
+            workstation_env.set_entry("K", bad_value)
+        assert not env_file.exists()
+
     def test_set_appends_new_name_and_chmods(self, env_file):
         workstation_env.set_entry("NEW", "val")
         assert "NEW=val" in env_file.read_text().splitlines()

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -157,6 +157,22 @@ class TestLookup:
         assert len(calls) == 1  # failure memoized, never re-run
         assert any(e["event"] == "workstation_env_command_failed" for e in cap)
 
+    def test_last_resolve_error_none_before_and_after_success(self, env_file, monkeypatch):
+        _write(env_file, "K=$(echo hi)\n")
+        monkeypatch.delenv("K", raising=False)
+        env = workstation_env.load()
+        assert env.last_resolve_error("K") is None
+        assert env.lookup("K") == "hi"
+        assert env.last_resolve_error("K") is None
+
+    def test_last_resolve_error_captures_stderr_on_failure(self, env_file, monkeypatch):
+        _write(env_file, "K=$(echo custom-error-message 1>&2; exit 3)\n")
+        monkeypatch.delenv("K", raising=False)
+        env = workstation_env.load()
+        with capture_logs():
+            assert env.resolve_file_value("K") is None
+        assert env.last_resolve_error("K") == "custom-error-message"
+
     def test_unknown_name_is_none(self, env_file, monkeypatch):
         _write(env_file, "K=v\n")
         monkeypatch.delenv("MISSING", raising=False)

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -94,6 +94,40 @@ class TestParser:
             workstation_env.load()
         assert any(e["event"] == "workstation_env_permissive_mode" for e in cap)
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+    def test_unreadable_file_degrades_to_empty_with_warning(self, env_file):
+        _write(env_file, "K=v\n")
+        os.chmod(env_file, 0o000)
+        try:
+            with capture_logs() as cap:
+                entries = workstation_env.load().entries()
+        finally:
+            os.chmod(env_file, 0o600)
+        assert entries == []
+        assert any(e["event"] == "workstation_env_unreadable" for e in cap)
+
+    def test_non_utf8_file_degrades_to_empty_with_warning(self, env_file):
+        env_file.write_bytes(b"K=\xff\xfe\n")
+        with capture_logs() as cap:
+            entries = workstation_env.load().entries()
+        assert entries == []
+        assert any(e["event"] == "workstation_env_unreadable" for e in cap)
+
+    def test_adjacent_command_substitutions_warn_but_still_classify_as_command(self, env_file):
+        # _COMMAND_RE's greedy DOTALL `.*` matches $(a)$(b) as ONE command
+        # whose inner text is "a)$(b" -- almost certainly a mistake. Still
+        # classified (and executed) as a command; a warning makes the
+        # resulting mangled-command failure diagnosable.
+        _write(env_file, "K=$(a)$(b)\n")
+        with capture_logs() as cap:
+            entry = workstation_env.load().get("K")
+        assert entry.kind == "command"
+        assert entry.command == "a)$(b"
+        assert any(
+            e["event"] == "workstation_env_suspicious_substitution" and e.get("name") == "K"
+            for e in cap
+        )
+
 
 class TestLookup:
     def test_real_env_beats_file(self, env_file, monkeypatch):
@@ -192,6 +226,18 @@ class TestLookup:
 
 
 class TestBootstrap:
+    @pytest.fixture(autouse=True)
+    def _no_injected_env_leak(self):
+        # inject_static() writes straight into os.environ, bypassing
+        # monkeypatch bookkeeping -- monkeypatch.delenv(..., raising=False)
+        # registers no undo when the var was already absent (pytest only
+        # records undo for keys that existed at delenv-time). Without this,
+        # a leaked INJ_* survives into later, unrelated tests in the same
+        # worker process (same pattern as test_lazy_settings.py:25-33).
+        yield
+        for name in ("INJ_A", "INJ_B", "INJ_C", "INJ_D"):
+            os.environ.pop(name, None)
+
     def test_inject_static_sets_absent_only(self, env_file, monkeypatch):
         _write(env_file, "INJ_A=filevalue\nINJ_B=filevalue\nINJ_C=$(echo never)\n")
         monkeypatch.setenv("INJ_B", "envwins")
@@ -236,7 +282,12 @@ class TestWriter:
             workstation_env.set_entry("K", "third")
         lines = env_file.read_text().splitlines()
         assert lines == ["K=first", "K=third"]
-        assert any(e["event"] == "workstation_env_duplicate_entries" for e in cap)
+        dup_events = [e for e in cap if e["event"] == "workstation_env_duplicate_entries"]
+        assert dup_events
+        # Line 2 ("K=second") is the occurrence that got overwritten; line 1
+        # ("K=first") is the "other" stale duplicate left behind -- the
+        # warning names it so the operator knows what to clean up.
+        assert dup_events[0]["lines"] == [1]
 
     def test_set_creates_parent_dir_and_file(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path / "deep" / "cfg"))

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -216,6 +216,26 @@ class TestLookup:
         _write(env_file, "A=static\nB=$(echo x)\nC=$(echo y)\n")
         assert workstation_env.load().command_entry_names() == {"B", "C"}
 
+    def test_empty_static_is_a_miss(self, env_file, monkeypatch):
+        # Unified empty-is-a-miss rule (A4): an empty static in the file
+        # must not surface as a hit of "" -- e.g. it would otherwise let a
+        # YAML `${VAR}` header silently render "Bearer " instead of raising
+        # the clear "not set" PluginError.
+        _write(env_file, "K=\n")
+        monkeypatch.delenv("K", raising=False)
+        assert workstation_env.load().lookup("K") is None
+        # resolve_file_value() is the deliberate exception: it keeps
+        # returning "" verbatim (gp config get --resolve distinguishes
+        # "empty" from "failed").
+        assert workstation_env.load().resolve_file_value("K") == ""
+
+    def test_empty_command_output_is_a_miss(self, env_file, monkeypatch):
+        _write(env_file, "K=$(true)\n")
+        monkeypatch.delenv("K", raising=False)
+        env = workstation_env.load()
+        assert env.lookup("K") is None
+        assert env.resolve_file_value("K") == ""
+
     def test_resolve_file_value_skips_env_tier(self, env_file, monkeypatch):
         # The --resolve primitive answers "what does the FILE say" even when
         # the real environment defines the name.

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -1,6 +1,7 @@
 """Tests for graftpunk.workstation_env (spec: docs/rfcs/2026-07-28-workstation-env.md)."""
 
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -91,3 +92,103 @@ class TestParser:
         with capture_logs() as cap:
             workstation_env.load()
         assert any(e["event"] == "workstation_env_permissive_mode" for e in cap)
+
+
+class TestLookup:
+    def test_real_env_beats_file(self, env_file, monkeypatch):
+        _write(env_file, "K=fromfile\n")
+        monkeypatch.setenv("K", "fromenv")
+        assert workstation_env.load().lookup("K") == "fromenv"
+
+    def test_empty_string_env_is_a_miss(self, env_file, monkeypatch):
+        # Intended behavior change vs. today's login flow: empty env falls
+        # through to the file tier.
+        _write(env_file, "K=fromfile\n")
+        monkeypatch.setenv("K", "")
+        assert workstation_env.load().lookup("K") == "fromfile"
+
+    def test_static_entry_resolves_without_subprocess(self, env_file, monkeypatch):
+        _write(env_file, "K=v\n")
+        monkeypatch.delenv("K", raising=False)
+
+        def boom(*a, **kw):
+            raise AssertionError("no subprocess for statics")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert workstation_env.load().lookup("K") == "v"
+
+    def test_command_entry_executes_and_strips_one_newline(self, env_file, monkeypatch):
+        _write(env_file, "K=$(printf 'secret\\n')\n")
+        monkeypatch.delenv("K", raising=False)
+        assert workstation_env.load().lookup("K") == "secret"
+
+    def test_command_memoized_single_subprocess(self, env_file, monkeypatch):
+        _write(env_file, "K=$(echo hi)\n")
+        monkeypatch.delenv("K", raising=False)
+        env = workstation_env.load()
+        calls = []
+        real_run = subprocess.run
+
+        def counting_run(*a, **kw):
+            calls.append(a)
+            return real_run(*a, **kw)
+
+        monkeypatch.setattr(subprocess, "run", counting_run)
+        assert env.lookup("K") == "hi"
+        assert env.lookup("K") == "hi"
+        assert len(calls) == 1
+
+    def test_command_failure_memoized_returns_none_and_logs(self, env_file, monkeypatch):
+        _write(env_file, "K=$(exit 3)\n")
+        monkeypatch.delenv("K", raising=False)
+        env = workstation_env.load()
+        calls = []
+        real_run = subprocess.run
+
+        def counting_run(*a, **kw):
+            calls.append(a)
+            return real_run(*a, **kw)
+
+        monkeypatch.setattr(subprocess, "run", counting_run)
+        with capture_logs() as cap:
+            assert env.lookup("K") is None
+            assert env.lookup("K") is None
+        assert len(calls) == 1  # failure memoized, never re-run
+        assert any(e["event"] == "workstation_env_command_failed" for e in cap)
+
+    def test_unknown_name_is_none(self, env_file, monkeypatch):
+        _write(env_file, "K=v\n")
+        monkeypatch.delenv("MISSING", raising=False)
+        assert workstation_env.load().lookup("MISSING") is None
+
+    def test_command_entry_names(self, env_file):
+        _write(env_file, "A=static\nB=$(echo x)\nC=$(echo y)\n")
+        assert workstation_env.load().command_entry_names() == {"B", "C"}
+
+    def test_resolve_file_value_skips_env_tier(self, env_file, monkeypatch):
+        # The --resolve primitive answers "what does the FILE say" even when
+        # the real environment defines the name.
+        _write(env_file, "K=fromfile\n")
+        monkeypatch.setenv("K", "fromenv")
+        assert workstation_env.load().resolve_file_value("K") == "fromfile"
+        assert workstation_env.load().lookup("K") == "fromenv"
+
+
+class TestBootstrap:
+    def test_inject_static_sets_absent_only(self, env_file, monkeypatch):
+        _write(env_file, "INJ_A=filevalue\nINJ_B=filevalue\nINJ_C=$(echo never)\n")
+        monkeypatch.setenv("INJ_B", "envwins")
+        monkeypatch.delenv("INJ_A", raising=False)
+        monkeypatch.delenv("INJ_C", raising=False)
+        workstation_env.load().inject_static()
+        assert os.environ["INJ_A"] == "filevalue"
+        assert os.environ["INJ_B"] == "envwins"
+        assert "INJ_C" not in os.environ  # commands never injected
+
+    def test_ensure_bootstrap_idempotent(self, env_file, monkeypatch):
+        _write(env_file, "INJ_D=v\n")
+        monkeypatch.delenv("INJ_D", raising=False)
+        workstation_env.ensure_bootstrap()
+        os.environ["INJ_D"] = "changed"
+        workstation_env.ensure_bootstrap()  # second call must not re-inject
+        assert os.environ["INJ_D"] == "changed"

--- a/tests/unit/test_workstation_env.py
+++ b/tests/unit/test_workstation_env.py
@@ -1,8 +1,6 @@
 """Tests for graftpunk.workstation_env (spec: docs/rfcs/2026-07-28-workstation-env.md)."""
 
 import os
-import stat
-import subprocess
 from pathlib import Path
 
 import pytest

--- a/tests/unit/test_workstation_env_lifecycle.py
+++ b/tests/unit/test_workstation_env_lifecycle.py
@@ -1,0 +1,93 @@
+"""Lifecycle-faithful tests (spec § Testing 1, 2, 11).
+
+These drive the REAL entry path in a SPAWNED interpreter — true process
+isolation, so production import order is exercised without mutating the
+test process's sys.modules (no stale module identities, no re-run
+import-time plugin registration poisoning the in-process suite). Laziness
+is observed via sentinel files the command values would create if executed
+— no cross-process spying needed.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def _run_child(tmp_path, script: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["GRAFTPUNK_CONFIG_DIR"] = str(tmp_path)
+    env.pop("GRAFTPUNK_BROWSER_EXECUTABLE_PATH", None)
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+
+
+def _write_env_file(tmp_path, content: str) -> None:
+    # Real workstation env files are always written via workstation_env's
+    # _atomic_write, which chmods 0600 on every write. Match that here —
+    # otherwise the default umask leaves the file group/other-readable,
+    # workstation_env.load() logs a workstation_env_permissive_mode
+    # warning, and (since this fires during ensure_bootstrap(), before
+    # cli/main.py's configure_logging() call rewires structlog to
+    # stderr) that warning lands on stdout via structlog's default
+    # PrintLoggerFactory — polluting the exact stdout match below with
+    # noise unrelated to the ordering/laziness invariant under test.
+    path = tmp_path / "env"
+    path.write_text(content)
+    path.chmod(0o600)
+
+
+def test_real_order_static_visibility(tmp_path):
+    # Spec Testing #1: importing the real CLI module runs bootstrap BEFORE
+    # import-time plugin discovery constructs the settings singleton. This
+    # test fails if injection ever moves after settings construction.
+    _write_env_file(tmp_path, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/from/file/chrome\n")
+    result = _run_child(
+        tmp_path,
+        "import graftpunk.cli.main\n"
+        "from graftpunk.config import get_settings\n"
+        "print(get_settings().browser_executable_path)\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "/from/file/chrome"
+
+
+def test_laziness_regression_help_runs_zero_commands(tmp_path):
+    # Spec Testing #2: with command entries present (credentials AND an
+    # allowlisted settings field), gp --help must execute ZERO of them.
+    # Each command value would create a sentinel file if it ever ran.
+    _write_env_file(
+        tmp_path,
+        f"SHOPKEEP_PASSWORD=$(touch {tmp_path}/CRED_EVALUATED; echo secret)\n"
+        f"GRAFTPUNK_BROWSER_EXECUTABLE_PATH=$(touch {tmp_path}/SETTING_EVALUATED; echo /lazy)\n",
+    )
+    result = _run_child(
+        tmp_path,
+        "from typer.testing import CliRunner\n"
+        "from graftpunk.cli.main import app\n"
+        "r = CliRunner().invoke(app, ['--help'])\n"
+        "raise SystemExit(r.exit_code)\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "CRED_EVALUATED").exists()
+    assert not (tmp_path / "SETTING_EVALUATED").exists()
+
+
+def test_library_reach_without_cli_import(tmp_path):
+    # Spec Testing #11: a consumer that never imports graftpunk.cli (e.g.
+    # grocerbot's in-process GraftpunkClient) sees file statics identically —
+    # ensure_bootstrap() lives inside get_settings(), not in the CLI.
+    # (Match exactly graftpunk.cli / graftpunk.cli.* — a bare startswith
+    # would false-positive on graftpunk.client, which the package __init__
+    # imports.)
+    _write_env_file(tmp_path, "GRAFTPUNK_BROWSER_EXECUTABLE_PATH=/from/file/chrome\n")
+    result = _run_child(
+        tmp_path,
+        "import sys\n"
+        "from graftpunk.config import get_settings\n"
+        "assert not any(m == 'graftpunk.cli' or m.startswith('graftpunk.cli.')\n"
+        "               for m in sys.modules), 'CLI modules leaked into library path'\n"
+        "print(get_settings().browser_executable_path)\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "/from/file/chrome"

--- a/tests/unit/test_workstation_env_lifecycle.py
+++ b/tests/unit/test_workstation_env_lifecycle.py
@@ -73,6 +73,35 @@ def test_laziness_regression_help_runs_zero_commands(tmp_path):
     assert not (tmp_path / "SETTING_EVALUATED").exists()
 
 
+def test_bootstrap_warning_goes_to_stderr_not_stdout(tmp_path):
+    # Reviewer finding: ensure_bootstrap() used to run BEFORE
+    # configure_logging(), so any warning it emits (e.g. permissive file
+    # mode) printed via structlog's built-in default PrintLogger (stdout)
+    # instead of the CLI's configured stderr renderer -- corrupting piped
+    # `gp` output for CSV/JSON consumers. A deliberately 0644 env file
+    # triggers workstation_env_permissive_mode at import time, inside
+    # cli.main's module-scope ensure_bootstrap() call. Calls the real Typer
+    # app object directly (not CliRunner, which redirects sys.stdout/stderr
+    # to an in-memory buffer that never reaches this test's subprocess-level
+    # capture) so stdout/stderr are exactly what a real `gp` invocation
+    # would produce.
+    path = tmp_path / "env"
+    path.write_text("K=v\n")
+    path.chmod(0o644)
+    result = _run_child(
+        tmp_path,
+        "import sys\n"
+        "from graftpunk.cli.main import app\n"
+        "try:\n"
+        "    app(['config', 'path'])\n"
+        "except SystemExit as e:\n"
+        "    sys.exit(e.code or 0)\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(path)  # stdout carries ONLY the path
+    assert "workstation_env_permissive_mode" in result.stderr
+
+
 def test_library_reach_without_cli_import(tmp_path):
     # Spec Testing #11: a consumer that never imports graftpunk.cli (e.g.
     # grocerbot's in-process GraftpunkClient) sees file statics identically —

--- a/tests/unit/test_workstation_env_lifecycle.py
+++ b/tests/unit/test_workstation_env_lifecycle.py
@@ -12,6 +12,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 
 def _run_child(tmp_path, script: str) -> subprocess.CompletedProcess:
     env = os.environ.copy()
@@ -100,6 +102,35 @@ def test_bootstrap_warning_goes_to_stderr_not_stdout(tmp_path):
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(path)  # stdout carries ONLY the path
     assert "workstation_env_permissive_mode" in result.stderr
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses permission bits")
+def test_unreadable_env_file_does_not_crash_gp(tmp_path):
+    # Reviewer finding (A1): load()'s unguarded stat()/read_text() used to
+    # let an unreadable file crash EVERY `gp` invocation (via
+    # ensure_bootstrap() at cli/main.py module scope) with a raw
+    # PermissionError traceback and no in-tool recovery -- including `gp
+    # config path`, which needs no file access at all. Same rationale as
+    # test_bootstrap_warning_goes_to_stderr_not_stdout above for spawning a
+    # real subprocess rather than using CliRunner.
+    path = tmp_path / "env"
+    path.write_text("K=v\n")
+    path.chmod(0o000)
+    try:
+        result = _run_child(
+            tmp_path,
+            "import sys\n"
+            "from graftpunk.cli.main import app\n"
+            "try:\n"
+            "    app(['config', 'path'])\n"
+            "except SystemExit as e:\n"
+            "    sys.exit(e.code or 0)\n",
+        )
+    finally:
+        path.chmod(0o600)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(path)  # stdout carries ONLY the path
+    assert "workstation_env_unreadable" in result.stderr
 
 
 def test_library_reach_without_cli_import(tmp_path):

--- a/tests/unit/test_yaml_loader.py
+++ b/tests/unit/test_yaml_loader.py
@@ -100,6 +100,21 @@ class TestExpandEnvVarsWorkstationFile:
         with pytest.raises(PluginError, match="TOTALLY_MISSING"):
             expand_env_vars("${TOTALLY_MISSING}")
 
+    def test_empty_static_in_file_raises_plugin_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty static (`K=`) in the file counts as a miss, not a hit of "".
+
+        Without the fix, this would silently render "Bearer " instead of
+        raising -- an opaque 401 downstream rather than a clear error.
+        """
+        from graftpunk.plugins.yaml_loader import expand_env_vars
+
+        (self.tmp_path / "env").write_text("EMPTY_KEY=\n")
+        monkeypatch.delenv("EMPTY_KEY", raising=False)
+        with pytest.raises(PluginError, match="EMPTY_KEY"):
+            expand_env_vars("Bearer ${EMPTY_KEY}")
+
 
 class TestValidateYamlSchema:
     """Tests for YAML schema validation."""

--- a/tests/unit/test_yaml_loader.py
+++ b/tests/unit/test_yaml_loader.py
@@ -50,6 +50,57 @@ class TestExpandEnvVars:
         assert result == "$NOT_A_PATTERN"
 
 
+class TestExpandEnvVarsWorkstationFile:
+    """Tests for environment variable expansion through workstation env file."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Invalidate workstation env cache before and after each test."""
+        from graftpunk import workstation_env
+
+        monkeypatch.setenv("GRAFTPUNK_CONFIG_DIR", str(tmp_path))
+        workstation_env._invalidate_cache()
+        self.tmp_path = tmp_path
+        yield
+        workstation_env._invalidate_cache()
+
+    def test_resolves_from_workstation_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test expanding variable from workstation env file."""
+        from graftpunk.plugins.yaml_loader import expand_env_vars
+
+        (self.tmp_path / "env").write_text("API_KEY=file-key\n")
+        monkeypatch.delenv("API_KEY", raising=False)
+        assert expand_env_vars("Bearer ${API_KEY}") == "Bearer file-key"
+
+    def test_env_still_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that environment variable takes precedence over file."""
+        from graftpunk.plugins.yaml_loader import expand_env_vars
+
+        (self.tmp_path / "env").write_text("API_KEY=file-key\n")
+        monkeypatch.setenv("API_KEY", "env-key")
+        assert expand_env_vars("${API_KEY}") == "env-key"
+
+    def test_empty_env_falls_through_to_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that empty-string env counts as a miss and falls through to file.
+
+        Unified semantics with the credential chain (spec § point (c)):
+        empty-string env counts as a miss.
+        """
+        from graftpunk.plugins.yaml_loader import expand_env_vars
+
+        (self.tmp_path / "env").write_text("API_KEY=file-key\n")
+        monkeypatch.setenv("API_KEY", "")
+        assert expand_env_vars("${API_KEY}") == "file-key"
+
+    def test_both_missing_raises_plugin_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that missing from both env and file raises PluginError."""
+        from graftpunk.plugins.yaml_loader import expand_env_vars
+
+        monkeypatch.delenv("TOTALLY_MISSING", raising=False)
+        with pytest.raises(PluginError, match="TOTALLY_MISSING"):
+            expand_env_vars("${TOTALLY_MISSING}")
+
+
 class TestValidateYamlSchema:
     """Tests for YAML schema validation."""
 


### PR DESCRIPTION
One file — `~/.config/graftpunk/env` — makes gp's credentials and settings work from any shell, any cwd: static values inject at bootstrap, `$(…)` command values (e.g. `$(op read …)`) resolve lazily at the moment something actually needs them. Managed by a git-config-style `gp config` family.

## Design
- **Spec:** `docs/rfcs/2026-07-28-workstation-env.md` (validate-blessed; includes the laziness contract — access-driven evaluation is the authors' responsibility)
- **Three consumption points, one precedence owner:** login credentials, allowlisted settings fields (a bounded `LazySettings` proxy over `GraftpunkSettings`; `PROXY_SAFE_FIELDS = {browser_executable_path}`), and YAML plugin `${VAR}` headers — all resolve through the single `WorkstationEnv.lookup()` (real env → file → miss; empty-string env counts as a miss, unified everywhere)
- **Bootstrap is entry-path-agnostic:** idempotent `ensure_bootstrap()` runs inside `get_settings()` (library consumers like grocerbot's in-process client get identical behavior) and at `cli/main.py` module scope (so file statics precede early logging config)
- **New modules:** `paths.py` (settings-free config-dir resolver, single owner), `workstation_env.py` (parser, lookup, surgical atomic writers), `cli/config_commands.py` (`gp config` — bare invocation keeps the old settings panel verbatim; `show`/`path`/`list`/`get [--resolve]`/`set`/`unset`/`edit`)

## Security posture
File is 0600 (re-asserted on every write, including after `edit`); command strings live on disk, secrets never do; resolved values are memoized per-process only; `set` warns when a secret-looking NAME gets a literal value (the forgot-to-single-quote footgun).

## Test plan
- [x] 60+ new tests across 7 files; full suite **2214 passed** (3 pre-existing JSON test-order failures, verified identical at merge-base — see follow-up note)
- [x] Lifecycle-faithful tests spawn real child interpreters: bootstrap-before-settings ordering, `gp --help` executes ZERO command entries (sentinel-file proof), library reach without importing the CLI, bootstrap warnings on stderr not stdout
- [x] **LIVE on the dev workstation:** real op-backed `SHOPKEEP_*` entries in `~/.config/graftpunk/env` — `gp --help` 0.299s with zero 1Password activity; `gp config get SHOPKEEP_USERNAME --resolve` resolved the real credential through op (4.5s); `[command]` markers in `gp config list`
- [x] ruff check + format clean (includes a chore commit formatting 4 pre-existing markdown files that newer ruff now checks — identical breakage existed at merge-base)
- [ ] Post-merge [manual]: next `gp shopkeep login` on a fresh shell with no exported env vars should resolve credentials from the file with exactly one Touch ID prompt

## Follow-up candidates (non-blocking, from review triage)
Pre-existing test-order dependency (3 JSON tests fail without test_cli.py in the same run); redundant per-file cache-invalidation fixtures now that conftest owns sandboxing; `$(a) $(b)` greedy-regex edge documented-not-handled.

## Polish round (polish-pr, both reviewers)
Both reviewers ran in parallel over the full 25-commit range; verdicts "With fixes" — **all 17 findings addressed in-PR** (commits `fa5c760`…`1d4c2e5`), none deferred:
- **Robustness:** an unreadable/non-UTF-8 env file no longer bricks every `gp` invocation (degrades to empty + warning, matching the spec's error posture); `gp config edit` handles multi-word editors (`EDITOR="code --wait"`) via shlex + clean OSError handling; `--resolve` failure output no longer mangles the command's stderr through Rich markup (both reviewers' reproductions confirmed fixed).
- **Semantics:** the empty-string-is-a-miss rule now genuinely covers the file tier too — an empty static or empty-output command is a miss in `lookup()` (YAML headers raise the clear PluginError instead of emitting `Bearer `); `resolve_file_value()` still distinguishes empty from failed for `gp config get --resolve`.
- **Typing/tooling:** the one new `ty` diagnostic eliminated (`just lint` passes again); `_atomic_write`/`__getattr__`/`__init__` annotations added.
- **Honesty fixes:** `load()`'s cache-coherence docstring now states that bootstrap-injected statics shadow same-process rewrites; RFC gains a case-sensitivity known-limitation note and corrects two mischaracterized "import-time" accesses; README documents the third lazy consumption point (YAML `${VAR}` headers) and the empty-string carve-out.
- Suite: **2227 passed** (3 pre-existing JSON test-order failures, unchanged from merge-base); ruff check + format clean; attribution sweep clean across all 29 commits.
