### PR TITLE
fix(observe): stop passing stale nodriver `_is_update` kwarg to eager body fetch (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Response-body capture on nodriver >= 0.50.1** ([#146](https://github.com/stavxyz/graftpunk/issues/146)). nodriver 0.50 renamed `Connection.send(..., _is_update)` to `_attach` and merges unknown kwargs into the CDP message, so the eager body fetch put `_is_update: true` on the wire and Chrome rejected every `Network.getResponseBody` with `-32600`; capture silently reverted to the eviction-limited late path. The eager fetch now passes `_is_update=True` only when the installed `send()` declares it (nodriver <= 0.48) and nothing otherwise. Measured on 0.50.3 with `gp --observe=full observe go https://www.python.org/`: 0 × `-32600`, 23 of 32 HAR entries with bodies.
+
 ## [1.12.0] - 2026-08-01
 
 ### Added

--- a/src/graftpunk/observe/capture.py
+++ b/src/graftpunk/observe/capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import datetime
+import inspect
 import json
 import os
 import tempfile
@@ -443,6 +444,30 @@ class SeleniumCaptureBackend:
         self.start_capture()
 
 
+def _eager_send_kwargs(tab: Any) -> dict[str, Any]:
+    """Internal kwargs for the eager body fetch, adapted to the installed nodriver.
+
+    nodriver <= 0.48 exposes ``Connection.send(cdp_obj, _is_update=False)``;
+    passing ``_is_update=True`` skips ``_register_handlers()`` on every fetch
+    (issue #64 Fix 2). nodriver >= 0.50.1 renamed the flag to ``_attach`` (which
+    also suppresses ``sessionId`` -- different semantics) and merges any unknown
+    kwargs straight into the CDP message, so a stale ``_is_update=True`` puts a
+    top-level property on the wire and Chrome rejects the whole command with
+    ``-32600`` (issue #146). 0.50's ``send()`` no longer re-registers handlers,
+    so there is nothing to skip there.
+
+    Only pass ``_is_update`` when ``send()`` actually declares it. If the
+    signature cannot be introspected, pass nothing rather than guess.
+    """
+    try:
+        params = inspect.signature(tab.send).parameters
+    except (TypeError, ValueError):
+        return {}
+    if "_is_update" in params:
+        return {"_is_update": True}
+    return {}
+
+
 class NodriverCaptureBackend:
     """Capture backend for nodriver (async Chrome DevTools Protocol).
 
@@ -570,7 +595,11 @@ class NodriverCaptureBackend:
             network.enable(  # type: ignore[attr-defined]
                 max_total_buffer_size=100 * 1024 * 1024,  # 100 MB total buffer
                 max_resource_buffer_size=10 * 1024 * 1024,  # 10 MB per resource
-                enable_durable_messages=True,  # hint to keep bodies longer (best-effort)
+                # Keeps bodies fetchable longer. Load-bearing on nodriver >= 0.50
+                # (flattened sessions): measured on 0.50.3, getResponseBody
+                # returns -32000 for every request without it and succeeds for
+                # nearly all with it. See issue #146.
+                enable_durable_messages=True,
             )
         )
         tab.add_handler(network.RequestWillBeSent, self._on_request)  # type: ignore[attr-defined]
@@ -723,7 +752,7 @@ class NodriverCaptureBackend:
 
             body, base64_encoded = await tab.send(
                 cdp_net.get_response_body(cdp_net.RequestId(rid)),  # type: ignore[attr-defined]
-                _is_update=True,  # nodriver internal: skip _register_handlers() re-registration
+                **_eager_send_kwargs(tab),
             )
             _process_response_body(
                 response=response,

--- a/src/graftpunk/observe/capture.py
+++ b/src/graftpunk/observe/capture.py
@@ -490,6 +490,8 @@ class NodriverCaptureBackend:
         self._console_logs: list[dict[str, Any]] = []
         self._warned_no_screenshots: bool = False
         self._bodies_fetched: set[str] = set()  # request IDs with eagerly-fetched bodies
+        self._eager_fetch_attempts: int = 0
+        self._eager_fetch_failures: int = 0
 
     @property
     def _tab(self) -> Any | None:
@@ -619,6 +621,21 @@ class NodriverCaptureBackend:
             return
 
         import nodriver.cdp.network as cdp_net
+
+        # One aggregate line so a systematic eager-fetch failure (e.g. a
+        # nodriver internals change, issue #146) is visible at a glance rather
+        # than buried in per-request warnings that read as ordinary eviction.
+        if self._eager_fetch_failures:
+            LOG.warning(
+                "nodriver_eager_body_fetch_summary",
+                failed=self._eager_fetch_failures,
+                attempted=self._eager_fetch_attempts,
+                hint=(
+                    "Bodies not fetched eagerly are retried below while the browser "
+                    "is alive; a 100% failure rate points at a nodriver/CDP mismatch, "
+                    "not eviction."
+                ),
+            )
 
         for request_id, data in list(self._request_map.items()):
             # Fetch POST body if has_post_data but no inline post_data
@@ -750,6 +767,7 @@ class NodriverCaptureBackend:
             if tab is None:
                 return
 
+            self._eager_fetch_attempts += 1
             body, base64_encoded = await tab.send(
                 cdp_net.get_response_body(cdp_net.RequestId(rid)),  # type: ignore[attr-defined]
                 **_eager_send_kwargs(tab),
@@ -765,6 +783,7 @@ class NodriverCaptureBackend:
             )
             self._bodies_fetched.add(rid)
         except Exception as exc:  # noqa: BLE001 — best-effort; stop_capture_async retries non-connection errors
+            self._eager_fetch_failures += 1
             url = data.get("url", "unknown") if data is not None else "unknown"
             LOG.warning(
                 "nodriver_eager_body_fetch_failed",

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1893,11 +1893,21 @@ class TestNodriverHARCapture:
         )
 
     @pytest.mark.asyncio
-    async def test_on_loading_finished_passes_is_update_true(self) -> None:
-        """Eager fetch uses _is_update=True to skip _register_handlers() overhead."""
+    async def test_on_loading_finished_passes_is_update_on_legacy_send(self) -> None:
+        """nodriver <= 0.48: send() has a real ``_is_update`` param; pass it to skip
+        _register_handlers() overhead (issue #64 Fix 2)."""
         browser = MagicMock()
-        tab = MagicMock()
-        tab.send = AsyncMock(return_value=('{"ok": true}', False))
+
+        class LegacyTab:
+            """Real async method so inspect.signature() sees the 0.48 signature."""
+
+            calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+            async def send(self, cdp_obj: Any, _is_update: bool = False) -> Any:
+                self.calls.append(((cdp_obj,), {"_is_update": _is_update}))
+                return ('{"ok": true}', False)
+
+        tab = LegacyTab()
 
         with _patch_cdp_modules():
             backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
@@ -1907,10 +1917,66 @@ class TestNodriverHARCapture:
             event.request_id = "req-fast"
             await backend._on_loading_finished(event)
 
-        # Verify _is_update=True was passed to tab.send()
-        tab.send.assert_called_once()
+        assert len(tab.calls) == 1
+        assert tab.calls[0][1] == {"_is_update": True}
+        assert "req-fast" in backend._bodies_fetched
+
+    @pytest.mark.asyncio
+    async def test_on_loading_finished_omits_is_update_on_nodriver_050(self) -> None:
+        """nodriver >= 0.50.1 renamed ``_is_update`` to ``_attach`` and merges unknown
+        kwargs into the CDP message, which Chrome rejects with -32600 (issue #146).
+        The eager fetch must not pass ``_is_update`` to such a send()."""
+        browser = MagicMock()
+
+        class ModernTab:
+            """Real async method mirroring nodriver 0.50.3's Connection.send()."""
+
+            calls: list[dict[str, Any]] = []
+
+            async def send(self, cdp_obj: Any, _attach: bool = False, **kwargs: Any) -> Any:
+                self.calls.append(kwargs)
+                if kwargs:
+                    raise RuntimeError(
+                        "Message has property other than 'id', 'method', 'sessionId', "
+                        "'params' [code: -32600]"
+                    )
+                return ('{"ok": true}', False)
+
+        tab = ModernTab()
+
+        with _patch_cdp_modules():
+            backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
+            backend._request_map["req-050"] = _make_request_entry()
+
+            event = MagicMock()
+            event.request_id = "req-050"
+            await backend._on_loading_finished(event)
+
+        assert tab.calls == [{}]
+        assert "req-050" in backend._bodies_fetched
+        assert backend._request_map["req-050"]["response"]["body"] == '{"ok": true}'
+
+    @pytest.mark.asyncio
+    async def test_on_loading_finished_omits_is_update_when_signature_unknown(self) -> None:
+        """If send() cannot be introspected, do not guess: pass no internal kwargs."""
+        browser = MagicMock()
+        tab = MagicMock()
+        tab.send = AsyncMock(return_value=('{"ok": true}', False))
+
+        with (
+            _patch_cdp_modules(),
+            patch("graftpunk.observe.capture.inspect.signature", side_effect=ValueError("no sig")),
+        ):
+            backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
+            backend._request_map["req-nosig"] = _make_request_entry()
+
+            event = MagicMock()
+            event.request_id = "req-nosig"
+            await backend._on_loading_finished(event)
+
         _, kwargs = tab.send.call_args
-        assert kwargs.get("_is_update") is True
+        assert kwargs == {}
+        assert "req-nosig" in backend._bodies_fetched
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1909,7 +1909,8 @@ class TestNodriverHARCapture:
         class LegacyTab:
             """Real async method so inspect.signature() sees the 0.48 signature."""
 
-            calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+            def __init__(self) -> None:
+                self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
             async def send(self, cdp_obj: Any, _is_update: bool = False) -> Any:
                 self.calls.append(((cdp_obj,), {"_is_update": _is_update}))
@@ -1928,6 +1929,7 @@ class TestNodriverHARCapture:
         assert len(tab.calls) == 1
         assert tab.calls[0][1] == {"_is_update": True}
         assert "req-fast" in backend._bodies_fetched
+        assert backend._request_map["req-fast"]["response"]["body"] == '{"ok": true}'
 
     @pytest.mark.asyncio
     async def test_on_loading_finished_omits_is_update_on_nodriver_050(self) -> None:
@@ -1939,7 +1941,8 @@ class TestNodriverHARCapture:
         class ModernTab:
             """Real async method mirroring nodriver 0.50.3's Connection.send()."""
 
-            calls: list[dict[str, Any]] = []
+            def __init__(self) -> None:
+                self.calls: list[dict[str, Any]] = []
 
             async def send(self, cdp_obj: Any, _attach: bool = False, **kwargs: Any) -> Any:
                 self.calls.append(kwargs)
@@ -1966,15 +1969,24 @@ class TestNodriverHARCapture:
 
     @pytest.mark.asyncio
     async def test_on_loading_finished_omits_is_update_when_signature_unknown(self) -> None:
-        """If send() cannot be introspected, do not guess: pass no internal kwargs."""
+        """If send() cannot be introspected, do not guess: pass no internal kwargs.
+
+        A bogus ``__signature__`` makes ``inspect.signature`` raise TypeError
+        (the arm a C-implemented callable would hit) without patching the stdlib
+        module process-wide.
+        """
         browser = MagicMock()
         tab = MagicMock()
-        tab.send = AsyncMock(return_value=('{"ok": true}', False))
+        calls: list[dict[str, Any]] = []
 
-        with (
-            _patch_cdp_modules(),
-            patch("graftpunk.observe.capture.inspect.signature", side_effect=ValueError("no sig")),
-        ):
+        async def send(cdp_obj: Any, **kwargs: Any) -> Any:
+            calls.append(kwargs)
+            return ('{"ok": true}', False)
+
+        send.__signature__ = "not a signature"  # type: ignore[attr-defined]
+        tab.send = send
+
+        with _patch_cdp_modules():
             backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
             backend._request_map["req-nosig"] = _make_request_entry()
 
@@ -1982,9 +1994,55 @@ class TestNodriverHARCapture:
             event.request_id = "req-nosig"
             await backend._on_loading_finished(event)
 
-        _, kwargs = tab.send.call_args
-        assert kwargs == {}
+        assert calls == [{}]
         assert "req-nosig" in backend._bodies_fetched
+
+    @pytest.mark.asyncio
+    async def test_stop_capture_logs_eager_fetch_summary_when_failures(self) -> None:
+        """A systematic eager-fetch failure surfaces once, with counts, at stop time."""
+        browser = MagicMock()
+        tab = MagicMock()
+        tab.send = AsyncMock(side_effect=RuntimeError("[code: -32600]"))
+
+        with _patch_cdp_modules(), patch("graftpunk.observe.capture.LOG") as mock_log:
+            backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
+            for rid in ("a", "b", "c"):
+                backend._request_map[rid] = _make_request_entry()
+                event = MagicMock()
+                event.request_id = rid
+                await backend._on_loading_finished(event)
+            # Late path should not raise either; bodies are simply absent.
+            tab.send = AsyncMock(side_effect=RuntimeError("[code: -32000]"))
+            await backend.stop_capture_async()
+
+        summaries = [
+            c
+            for c in mock_log.warning.call_args_list
+            if c.args[0] == "nodriver_eager_body_fetch_summary"
+        ]
+        assert len(summaries) == 1
+        assert summaries[0].kwargs["failed"] == 3
+        assert summaries[0].kwargs["attempted"] == 3
+
+    @pytest.mark.asyncio
+    async def test_stop_capture_no_summary_when_all_eager_fetches_succeed(self) -> None:
+        browser = MagicMock()
+        tab = MagicMock()
+        tab.send = AsyncMock(return_value=('{"ok": true}', False))
+
+        with _patch_cdp_modules(), patch("graftpunk.observe.capture.LOG") as mock_log:
+            backend = NodriverCaptureBackend(browser, get_tab=lambda: tab)
+            backend._request_map["a"] = _make_request_entry()
+            event = MagicMock()
+            event.request_id = "a"
+            await backend._on_loading_finished(event)
+            await backend.stop_capture_async()
+
+        assert not [
+            c
+            for c in mock_log.warning.call_args_list
+            if c.args[0] == "nodriver_eager_body_fetch_summary"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -1015,6 +1015,14 @@ class TestNodriverCaptureBackend:
 
     @pytest.mark.asyncio
     async def test_start_capture_async_enables_network_and_runtime(self) -> None:
+        """Pins the Network.enable arguments.
+
+        ``enable_durable_messages=True`` looks like a no-op hint on nodriver
+        0.48 but is load-bearing on >= 0.50 (flattened sessions): measured on
+        0.50.3, without it every Network.getResponseBody returns -32000, even
+        inside the LoadingFinished handler, and body capture silently dies
+        (issue #146). Do not remove it because a local test shows no effect.
+        """
         browser = MagicMock()
         tab = MagicMock()
         tab.send = AsyncMock()


### PR DESCRIPTION
## Summary
- nodriver >= 0.50.1 renamed `send(..., _is_update)` → `_attach` and merges unknown kwargs into the CDP message, so every eager `getResponseBody` was rejected with `-32600` and capture silently reverted to the eviction-limited late path (#146).
- `_eager_send_kwargs()` now passes `_is_update=True` only when the installed `send()` declares it (≤ 0.48); otherwise nothing. If the signature can't be introspected, it passes nothing rather than guess. (`inspect.signature` on a real `Tab.send` measured at ~4–5 µs; not worth caching.)
- Documents — in a code comment and in the test that pins the `Network.enable` arguments — that `enable_durable_messages=True` is load-bearing on 0.50 (measured: without it, every `getResponseBody` on 0.50.3 returns `-32000`, even inside the `LoadingFinished` handler).
- New `nodriver_eager_body_fetch_summary` warning (failed/attempted) at `stop_capture_async` time, so a systematic eager-fetch failure surfaces once as a recognisable signal instead of dozens of per-request lines that read as eviction noise — which is how #146 stayed invisible.
- CHANGELOG `[Unreleased]` entry.

## Verification
Same reproduction as the issue, `gp -vv --observe=full observe --no-session go https://www.python.org/`:

| nodriver | before | after |
|---|---|---|
| 0.50.3 | 27 × `-32600`, bodies only via late path | **0 × `-32600`, 23 of 32 entries with bodies** |
| 0.48.1 | works | unchanged (still passes `_is_update=True`) |

Unit tests: legacy 0.48-style `send()` gets the kwarg and the body lands; a 0.50.3-style `send(cdp_obj, _attach=False, **kwargs)` that raises on unknown kwargs gets none **and a body is actually captured**; an un-introspectable `send()` (bogus `__signature__`, the `TypeError` arm) gets none; the summary warning fires once with counts on 3/3 failures and not at all on success.

## Test plan
- [x] `NO_COLOR=1 uv run pytest tests/` → 2258 passed (the 7 ANSI-output tests fail on `main` too when `FORCE_COLOR=3` is exported; unrelated).
- [x] `ruff check` / `ruff format --check` clean; `ty` introduces no new diagnostics (the 30 existing ones are the known `nodriver.cdp.*` stub gap).
- [x] Issue repro on **nodriver 0.50.3** (branch installed into a throwaway venv): `observe go` → 0 × `-32600`, 32 HAR entries, 23 with bodies, run listed by `gp observe list`.
- [x] Issue repro on **nodriver 0.48.1** (project venv): plain and eager fetches both 100 % successful, `_is_update=True` still passed.
- [x] `inspect.signature(tab.send)` verified on real `Tab` objects from both installs: 0.48.1 → `['cdp_obj', '_is_update']`, 0.50.3 → `['cdp_obj', '_attach', 'kwargs']`.
- [ ] `[manual, post-merge]` On a machine with nodriver ≥ 0.50.1, run any `gp --observe=full <plugin> login` and confirm the transcript no longer contains `-32600` lines and no `nodriver_eager_body_fetch_summary` warning appears.

## Review
Two independent reviews (pr-review-toolkit and superpowers), both "ready to merge"; every finding at every severity was applied. One pre-existing bug surfaced by the `send()` call-site sweep — `delete_all_cookies` passing a raw string to `tab.send()` — is out of this PR's scope and filed as #152.

## On the suggested version ceiling
I did **not** add `nodriver<0.51`. The adaptive kwarg makes this call correct on both lineages, and a ceiling would have blocked 0.50.3, which works fine once the kwarg is gone. Both reviewers concurred. Happy to add one if you'd still rather pin.

Closes #146