### PR TITLE
fix(login): stale-node field fill, honest failure message, --observe=full on login, headless override (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`LoginConfig.headless` and `gp <plugin> login --headless` / `--headful`** ([#148](https://github.com/stavxyz/graftpunk/issues/148)). Declarative login no longer hardcodes a visible browser window: set `headless: true` on sites that need no CAPTCHA/2FA, and override either way per invocation. The flags are offered only on declarative logins.
+- **`--observe=full` now covers `gp <plugin> login`** ([#148](https://github.com/stavxyz/graftpunk/issues/148)). An observed login records a run under the plugin's session name — screenshot, page source, HAR with bodies and console logs on nodriver; HAR, console logs and an error screenshot on selenium — whether or not the login succeeds, and prints the run directory. Submitted credentials are scrubbed from the HAR before it is written (`graftpunk.observe.run.redact_har_entries`); session cookies are not, so treat the run as sensitive.
+
 ### Fixed
 
+- **Declarative login typed into a detached DOM node and blamed the credentials** ([#148](https://github.com/stavxyz/graftpunk/issues/148)). On sites that re-render the login form after load, the element handle could be stale by the time keys were sent; the browser then refused to submit the empty required field and the CLI reported "Check your credentials". The nodriver engine now re-selects, clears, types, waits for the renderer, and reads the value back from the live DOM by selector, retrying up to 3 times and failing with an error that names the field. The CLI message is cause-neutral, a `Too Many Requests` page is reported as rate limiting rather than a login failure, and the failure-text / success-element warnings say what was measured.
 - **Response-body capture on nodriver >= 0.50.1** ([#146](https://github.com/stavxyz/graftpunk/issues/146)). nodriver 0.50 renamed `Connection.send(..., _is_update)` to `_attach` and merges unknown kwargs into the CDP message, so the eager body fetch put `_is_update: true` on the wire and Chrome rejected every `Network.getResponseBody` with `-32600`; capture silently reverted to the eviction-limited late path. The eager fetch now passes `_is_update=True` only when the installed `send()` declares it (nodriver <= 0.48) and nothing otherwise. Measured on 0.50.3 with `gp --observe=full observe go https://www.python.org/`: 0 × `-32600`, 23 of 32 HAR entries with bodies.
 
 ## [1.12.0] - 2026-08-01

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -359,15 +359,17 @@ The top-level login configuration includes:
 - **`wait_for`** — Optional top-level wait for element before any steps begin.
 - **`failure`** — Optional text that indicates login failure.
 - **`success`** — Optional CSS selector that indicates login success.
-- **`headless`** — Run the login browser headless (default `false`, so a human can solve a CAPTCHA or 2FA prompt). `gp <plugin> login --headless` overrides it for one invocation.
+- **`headless`** — Run the login browser headless (default `false`, so a human can solve a CAPTCHA or 2FA prompt). `gp <plugin> login --headless` / `--headful` override it for one invocation in either direction; the flags are offered only on declarative logins (a plugin's own `login()` method cannot honour them).
 
 #### Field filling is verified
 
-Some server-rendered sites re-render their login form shortly after load (jQuery/select2 and friends). The element handle resolved for a field can be detached from the DOM by the time keys are sent; the keystrokes then go nowhere and the browser refuses to submit the empty `required` field. The nodriver engine guards against this: after typing it waits briefly, reads the field's value back from the live DOM by selector, and on mismatch re-selects, clears, and retypes (up to 3 attempts). If the value never lands, login fails with an error naming the field rather than the credentials.
+Some server-rendered sites re-render their login form shortly after load (jQuery/select2 and friends). The element handle resolved for a field can be detached from the DOM by the time keys are sent; the keystrokes then go nowhere and the browser refuses to submit the empty `required` field. The nodriver engine guards against this: each attempt re-selects the element, clears it, types, waits briefly (the browser acknowledges key events before the DOM value updates — reading back immediately makes things worse), and reads the field's value back from the live DOM by selector. An empty read-back means the value never reached the live element: it retries up to 3 times and then fails with an error naming the field rather than the credentials. A non-empty read-back that differs from what was typed (sites that lowercase, trim or mask input) is logged and accepted.
 
 #### Diagnosing a failed login
 
-`login` reporting a failure means the page did not reach the expected post-login state. The engine logs what it actually detected — the configured `failure` text, a missing `success` element, or a `Too Many Requests` (rate-limit) page — so read the warning before assuming bad credentials. To capture the whole flow, run `gp --observe=full <plugin> login`: it records an observe run (screenshot, page source, HAR with bodies, console logs) under the plugin's session name, whether or not the login succeeds. `gp observe list` shows it.
+`login` reporting a failure means the page did not reach the expected post-login state. The engine logs what it actually detected — the configured `failure` text, a missing `success` element, or a `Too Many Requests` (rate-limit) page — so read the warning before assuming bad credentials. To capture the whole flow, run `gp --observe=full <plugin> login`: it records an observe run under the plugin's session name whether or not the login succeeds, and prints the run directory. `gp observe list` shows it. With the nodriver backend the run holds a screenshot, the page source, a HAR with response bodies, and console logs; with the selenium backend `BrowserSession` owns the capture, which yields the HAR, console logs, and a screenshot only if the login raised.
+
+**The run is sensitive.** The credentials you submitted are scrubbed from the HAR (raw, URL-encoded, JSON-escaped and base64 forms), but the exchange still contains the session cookies the login minted, and response bodies streamed to the run's `bodies/` directory are not scanned. Treat the run directory like a cached session, and delete it when you are done.
 
 #### Single-Step Login (Traditional Form)
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -359,6 +359,15 @@ The top-level login configuration includes:
 - **`wait_for`** — Optional top-level wait for element before any steps begin.
 - **`failure`** — Optional text that indicates login failure.
 - **`success`** — Optional CSS selector that indicates login success.
+- **`headless`** — Run the login browser headless (default `false`, so a human can solve a CAPTCHA or 2FA prompt). `gp <plugin> login --headless` overrides it for one invocation.
+
+#### Field filling is verified
+
+Some server-rendered sites re-render their login form shortly after load (jQuery/select2 and friends). The element handle resolved for a field can be detached from the DOM by the time keys are sent; the keystrokes then go nowhere and the browser refuses to submit the empty `required` field. The nodriver engine guards against this: after typing it waits briefly, reads the field's value back from the live DOM by selector, and on mismatch re-selects, clears, and retypes (up to 3 attempts). If the value never lands, login fails with an error naming the field rather than the credentials.
+
+#### Diagnosing a failed login
+
+`login` reporting a failure means the page did not reach the expected post-login state. The engine logs what it actually detected — the configured `failure` text, a missing `success` element, or a `Too Many Requests` (rate-limit) page — so read the warning before assuming bad credentials. To capture the whole flow, run `gp --observe=full <plugin> login`: it records an observe run (screenshot, page source, HAR with bodies, console logs) under the plugin's session name, whether or not the login succeeds. `gp observe list` shows it.
 
 #### Single-Step Login (Traditional Form)
 
@@ -436,6 +445,7 @@ login:
   url: /login
   wait_for: "#login-form"
   failure: "Invalid credentials"
+  headless: false  # default; true for sites that need no CAPTCHA/2FA
   steps:
     - fields:
         username: "input#signInName"
@@ -1113,7 +1123,7 @@ This creates: `gp bank accounts list`, `gp bank accounts detail <id>`, `gp bank 
 | `CommandSpec` | `plugins.cli_plugin` | Yes | Command spec: `name`, `handler`, `help_text`, `params`, `timeout`, `max_retries`, `rate_limit`, `requires_session`, `group` |
 | `CommandMetadata` | `plugins.cli_plugin` | Yes | Metadata stored by `@command` decorator on methods |
 | `CommandGroupMeta` | `plugins.cli_plugin` | Yes | Metadata stored by `@command` decorator on classes (command groups) |
-| `LoginConfig` | `plugins.cli_plugin` | Yes | Declarative browser login configuration: `steps`, `url`, `wait_for`, `failure`, `success` |
+| `LoginConfig` | `plugins.cli_plugin` | Yes | Declarative browser login configuration: `steps`, `url`, `wait_for`, `failure`, `success`, `headless` |
 | `LoginStep` | `plugins.cli_plugin` | Yes | Single step in a login flow: `fields`, `submit`, `wait_for`, `delay` |
 | `PluginConfig` | `plugins.cli_plugin` | Yes | Canonical config: `site_name`, `session_name`, `help_text`, `base_url`, `requires_session`, `backend`, `api_version`, `username_envvar`, `password_envvar`, `login_config`, `plugin_version`, `plugin_author`, `plugin_url` |
 | `PluginParamSpec` | `plugins.cli_plugin` | Yes | CLI parameter specification |

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -369,6 +369,8 @@ Some server-rendered sites re-render their login form shortly after load (jQuery
 
 `login` reporting a failure means the page did not reach the expected post-login state. The engine logs what it actually detected — the configured `failure` text, a missing `success` element, or a `Too Many Requests` (rate-limit) page — so read the warning before assuming bad credentials. To capture the whole flow, run `gp --observe=full <plugin> login`: it records an observe run under the plugin's session name whether or not the login succeeds, and prints the run directory. `gp observe list` shows it. With the nodriver backend the run holds a screenshot, the page source, a HAR with response bodies, and console logs; with the selenium backend `BrowserSession` owns the capture, which yields the HAR, console logs, and a screenshot only if the login raised.
 
+**One current gap:** the capture keeps only the final hop of a redirect chain, so a login form whose `POST` answers with a redirect is recorded as the redirect target only — the POST itself is absent from the HAR (XHR/JSON logins are captured in full). Tracked in [#153](https://github.com/stavxyz/graftpunk/issues/153).
+
 **The run is sensitive.** The credentials you submitted are scrubbed from the HAR (raw, URL-encoded, JSON-escaped and base64 forms), but the exchange still contains the session cookies the login minted, and response bodies streamed to the run's `bodies/` directory are not scanned. Treat the run directory like a cached session, and delete it when you are done.
 
 #### Single-Step Login (Traditional Form)

--- a/src/graftpunk/cli/login_commands.py
+++ b/src/graftpunk/cli/login_commands.py
@@ -105,11 +105,13 @@ def _observe_mode_from_ctx(ctx: Any) -> str:
 
 
 def _accepted_login_kwargs(login_callable: Callable[..., Any], **candidates: Any) -> dict[str, Any]:
-    """Keep only the kwargs ``login_callable`` declares (or ``**kwargs``).
+    """Keep only the kwargs ``login_callable`` declares as optional (or ``**kwargs``).
 
     Generated declarative logins accept ``headless`` and ``observe_mode``; a
     plugin's hand-written ``login(credentials)`` usually does not, and must
-    not receive arguments it never asked for.
+    not receive arguments it never asked for. A same-named *required*
+    positional parameter does not count either: it would receive ``None``
+    for an unset flag, which is not what such a signature means.
     """
     try:
         params = inspect.signature(login_callable).parameters
@@ -117,7 +119,20 @@ def _accepted_login_kwargs(login_callable: Callable[..., Any], **candidates: Any
         return {}
     if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
         return dict(candidates)
-    return {k: v for k, v in candidates.items() if k in params}
+    return {
+        k: v
+        for k, v in candidates.items()
+        if k in params
+        and (
+            params[k].kind is inspect.Parameter.KEYWORD_ONLY
+            or params[k].default is not inspect.Parameter.empty
+        )
+    }
+
+
+def _supports_headless(login_callable: Callable[..., Any]) -> bool:
+    """True when the login callable takes a ``headless`` kwarg (generated logins do)."""
+    return "headless" in _accepted_login_kwargs(login_callable, headless=None)
 
 
 def make_login_body(
@@ -145,8 +160,14 @@ def make_login_body(
 
     def body(ctx: typer.Context, **kwargs: Any) -> None:
         login_method = login_callable
-        # --headless set -> force headless; unset -> None, i.e. LoginConfig decides.
-        headless_override: bool | None = True if kwargs.pop("headless", False) else None
+        # --headless -> True, --headful -> False, neither -> None (LoginConfig decides).
+        want_headless = bool(kwargs.pop("headless", False))
+        want_headful = bool(kwargs.pop("headful", False))
+        if want_headless and want_headful:
+            raise typer.BadParameter("--headless and --headful are mutually exclusive")
+        headless_override: bool | None = (
+            True if want_headless else (False if want_headful else None)
+        )
         login_kwargs = _accepted_login_kwargs(
             login_method,
             headless=headless_override,
@@ -226,22 +247,44 @@ def create_login_fn(
     login_callable: Callable[..., Any],
     fields: dict[str, str],
 ) -> Callable[..., None]:
-    """Synthesize the zero-parameter ``login`` command function."""
-    from graftpunk.cli.command_factory import synthesize_command_fn
+    """Synthesize the ``login`` command function.
 
-    help_text = inspect.getdoc(login_callable) or f"Log in to {plugin.site_name}"
-    help_text = help_text.split("\n")[0]
+    Credentials are gathered at runtime (env, workstation file, prompts), so
+    the only parameters are ``--headless`` / ``--headful``, and those only
+    when the login callable can honour them (generated declarative logins;
+    a hand-written ``login(credentials)`` gets neither, rather than an
+    advertised flag that silently does nothing).
+    """
+    from graftpunk.cli.command_factory import synthesize_command_fn
     from graftpunk.plugins.cli_plugin import PluginParamSpec
 
-    headless_flag = PluginParamSpec.option(
-        "headless",
-        type=bool,
-        default=False,
-        help="Run the login browser headless (overrides LoginConfig.headless).",
-    )
+    if getattr(login_callable, "_gp_generated_login", False):
+        # The generated login's docstring describes the engine, not the site.
+        help_text = f"Log in to {plugin.site_name}"
+    else:
+        help_text = inspect.getdoc(login_callable) or f"Log in to {plugin.site_name}"
+        help_text = help_text.split("\n")[0]
+
+    param_specs: list[PluginParamSpec] = []
+    if _supports_headless(login_callable):
+        param_specs = [
+            PluginParamSpec.option(
+                "headless",
+                type=bool,
+                default=False,
+                help="Run the login browser headless (overrides LoginConfig.headless).",
+            ),
+            PluginParamSpec.option(
+                "headful",
+                type=bool,
+                default=False,
+                help="Show the browser window even if LoginConfig.headless is true "
+                "(e.g. to solve a CAPTCHA or 2FA prompt).",
+            ),
+        ]
     return synthesize_command_fn(
         name="login",
-        param_specs=[headless_flag],
+        param_specs=param_specs,
         body=make_login_body(plugin, login_callable, fields),
         plugin_name=plugin.site_name,
         include_builtin_options=False,

--- a/src/graftpunk/cli/login_commands.py
+++ b/src/graftpunk/cli/login_commands.py
@@ -96,6 +96,30 @@ def resolve_login_fields(plugin: CLIPluginProtocol) -> dict[str, str]:
     return {"username": "", "password": ""}
 
 
+def _observe_mode_from_ctx(ctx: Any) -> str:
+    """Read ``--observe`` from the root Typer context; "off" when unavailable."""
+    try:
+        return str((ctx.find_root().obj or {}).get("observe_mode", "off"))
+    except AttributeError:
+        return "off"
+
+
+def _accepted_login_kwargs(login_callable: Callable[..., Any], **candidates: Any) -> dict[str, Any]:
+    """Keep only the kwargs ``login_callable`` declares (or ``**kwargs``).
+
+    Generated declarative logins accept ``headless`` and ``observe_mode``; a
+    plugin's hand-written ``login(credentials)`` usually does not, and must
+    not receive arguments it never asked for.
+    """
+    try:
+        params = inspect.signature(login_callable).parameters
+    except (TypeError, ValueError):
+        return {}
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return dict(candidates)
+    return {k: v for k, v in candidates.items() if k in params}
+
+
 def make_login_body(
     plugin: CLIPluginProtocol,
     login_callable: Callable[..., Any],
@@ -119,8 +143,15 @@ def make_login_body(
     if password_envvar:
         envvar_overrides["password"] = password_envvar
 
-    def body(ctx: typer.Context, **kwargs: Any) -> None:  # noqa: ARG001 — zero params by design
+    def body(ctx: typer.Context, **kwargs: Any) -> None:
         login_method = login_callable
+        # --headless set -> force headless; unset -> None, i.e. LoginConfig decides.
+        headless_override: bool | None = True if kwargs.pop("headless", False) else None
+        login_kwargs = _accepted_login_kwargs(
+            login_method,
+            headless=headless_override,
+            observe_mode=_observe_mode_from_ctx(ctx),
+        )
         credentials: dict[str, str] = {}
         site_prefix = plugin.site_name.upper().replace("-", "_").replace(" ", "_")
 
@@ -153,9 +184,9 @@ def make_login_body(
                     from graftpunk.logging import suppress_asyncio_noise
 
                     with suppress_asyncio_noise():
-                        result = asyncio.run(login_method(credentials))
+                        result = asyncio.run(login_method(credentials, **login_kwargs))
                 else:
-                    result = login_method(credentials)
+                    result = login_method(credentials, **login_kwargs)
 
             if result is False:
                 # The engine logged what it actually detected (failure text,
@@ -200,9 +231,17 @@ def create_login_fn(
 
     help_text = inspect.getdoc(login_callable) or f"Log in to {plugin.site_name}"
     help_text = help_text.split("\n")[0]
+    from graftpunk.plugins.cli_plugin import PluginParamSpec
+
+    headless_flag = PluginParamSpec.option(
+        "headless",
+        type=bool,
+        default=False,
+        help="Run the login browser headless (overrides LoginConfig.headless).",
+    )
     return synthesize_command_fn(
         name="login",
-        param_specs=[],
+        param_specs=[headless_flag],
         body=make_login_body(plugin, login_callable, fields),
         plugin_name=plugin.site_name,
         include_builtin_options=False,

--- a/src/graftpunk/cli/login_commands.py
+++ b/src/graftpunk/cli/login_commands.py
@@ -158,8 +158,13 @@ def make_login_body(
                     result = login_method(credentials)
 
             if result is False:
+                # The engine logged what it actually detected (failure text,
+                # missing success element, rate limiting, a field that never
+                # accepted input). Do not name a cause that was not measured.
                 gp_console.error(
-                    f"Login failed for {plugin.site_name}. Check your credentials and try again."
+                    f"Login did not complete for {plugin.site_name}: the page did not "
+                    "reach the expected post-login state. See the warning above for "
+                    "what was detected. Re-run with --observe=full to capture the flow."
                 )
                 raise SystemExit(1)
             if result is not True:

--- a/src/graftpunk/cli/main.py
+++ b/src/graftpunk/cli/main.py
@@ -554,40 +554,9 @@ async def _save_observe_results(
     screenshot_label: str,
 ) -> None:
     """Save screenshot, page source, HAR, and console logs."""
-    screenshot_data = await backend.take_screenshot()
-    page_source = await backend.get_page_source()
+    from graftpunk.observe.run import save_observe_run
 
-    if screenshot_data is None and page_source is None:
-        console.print(
-            "[yellow]Browser disconnected — screenshot and page source unavailable[/yellow]"
-        )
-    else:
-        if screenshot_data:
-            path = storage.save_screenshot(1, screenshot_label, screenshot_data)
-            console.print(f"[green]Screenshot saved:[/green] {path}")
-        else:
-            console.print("[yellow]Screenshot capture failed[/yellow]")
-
-        if page_source:
-            source_path = storage.run_dir / "page-source.html"
-            source_path.write_text(page_source, encoding="utf-8")
-            console.print(f"[green]Page source saved:[/green] {source_path}")
-        else:
-            console.print("[yellow]Page source capture failed[/yellow]")
-
-    await backend.stop_capture_async()
-
-    har_entries = backend.get_har_entries()
-    if har_entries:
-        storage.write_har(har_entries)
-        console.print(f"[green]HAR data saved:[/green] {len(har_entries)} entries")
-
-    console_logs = backend.get_console_logs()
-    if console_logs:
-        storage.write_console_logs(console_logs)
-        console.print(f"[green]Console logs saved:[/green] {len(console_logs)} entries")
-
-    console.print(f"\n[bold]Observe run:[/bold] {storage.run_dir}")
+    await save_observe_run(storage, backend, screenshot_label, console=console)
 
 
 async def _run_observe_go(

--- a/src/graftpunk/cli/main.py
+++ b/src/graftpunk/cli/main.py
@@ -35,6 +35,7 @@ from graftpunk.cli.session_commands import session_app
 from graftpunk.config import get_settings
 from graftpunk.logging import configure_logging, enable_network_debug, get_logger
 from graftpunk.observe import OBSERVE_BASE_DIR
+from graftpunk.observe.run import make_run_id, save_observe_run
 from graftpunk.plugins import (
     discover_keepalive_handlers,
     discover_site_plugins,
@@ -450,7 +451,6 @@ async def _setup_observe_session(
         Tuple of (browser, tab, storage, backend) or None on failure.
         The returned tab is the post-navigation tab.
     """
-    import datetime
 
     import nodriver
 
@@ -530,7 +530,7 @@ async def _setup_observe_session(
             msg += "[/dim]"
             console.print(msg)
 
-        run_id = datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + f"-{os.getpid()}"
+        run_id = make_run_id()
         storage = ObserveStorage(OBSERVE_BASE_DIR, namespace, run_id)
         bodies_dir = storage.run_dir / "bodies"
         backend = NodriverCaptureBackend(
@@ -548,17 +548,6 @@ async def _setup_observe_session(
         raise
 
 
-async def _save_observe_results(
-    storage: Any,
-    backend: Any,
-    screenshot_label: str,
-) -> None:
-    """Save screenshot, page source, HAR, and console logs."""
-    from graftpunk.observe.run import save_observe_run
-
-    await save_observe_run(storage, backend, screenshot_label, console=console)
-
-
 async def _run_observe_go(
     namespace: str, url: str, wait: float, max_body_size: int, *, session_name: str | None = None
 ) -> None:
@@ -573,7 +562,7 @@ async def _run_observe_go(
 
     try:
         await tab.sleep(wait)
-        await _save_observe_results(storage, backend, "observe-go")
+        await save_observe_run(storage, backend, "observe-go", console=console)
     finally:
         browser.stop()
 
@@ -615,7 +604,7 @@ async def _run_observe_interactive(
             loop.remove_signal_handler(signal.SIGINT)
 
         console.print("\n[dim]Recording stopped. Saving capture...[/dim]")
-        await _save_observe_results(storage, backend, "interactive-final")
+        await save_observe_run(storage, backend, "interactive-final", console=console)
     finally:
         browser.stop()
 

--- a/src/graftpunk/observe/capture.py
+++ b/src/graftpunk/observe/capture.py
@@ -244,9 +244,11 @@ class SeleniumCaptureBackend:
         self._bodies_dir = bodies_dir
         self._request_map: dict[str, dict[str, Any]] = {}
         self._console_logs: list[dict[str, Any]] = []
+        self._stopped: bool = False
 
     def start_capture(self) -> None:
         """Begin capturing browser data."""
+        self._stopped = False
         LOG.debug("selenium_capture_started")
 
     def stop_capture(self) -> None:
@@ -255,7 +257,16 @@ class SeleniumCaptureBackend:
         Parses Network.requestWillBeSent, Network.responseReceived, and
         Runtime.consoleAPICalled events from the performance log. Then fetches
         POST bodies and response bodies via CDP commands.
+
+        Idempotent: the performance log is drained on the first call and a
+        second call (e.g. the login engine extracting header roles, then
+        BrowserSession.__exit__ flushing observe data) must not re-fetch every
+        body and log one eviction warning per request.
         """
+        if self._stopped:
+            LOG.debug("selenium_capture_already_stopped")
+            return
+        self._stopped = True
         # Parse performance log for network and console events
         try:
             perf_log = self._driver.get_log("performance")

--- a/src/graftpunk/observe/run.py
+++ b/src/graftpunk/observe/run.py
@@ -1,0 +1,82 @@
+"""Observe run lifecycle helpers shared by the CLI and the login engine."""
+
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any
+
+from graftpunk.logging import get_logger
+from graftpunk.observe.storage import ObserveStorage
+
+LOG = get_logger(__name__)
+
+
+def make_run_id() -> str:
+    """Return a timestamp+pid run id (unique per process per second)."""
+    return datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + f"-{os.getpid()}"
+
+
+async def save_observe_run(
+    storage: ObserveStorage,
+    backend: Any,
+    screenshot_label: str,
+    *,
+    console: Any | None = None,
+) -> None:
+    """Persist a nodriver observe run: screenshot, page source, HAR, console logs.
+
+    ``backend.stop_capture_async()`` runs after the screenshot/page-source
+    grab so the late body fetch happens while the browser is still alive.
+    Progress lines go to ``console`` (a rich Console) when given; otherwise
+    only the log carries them.
+
+    Args:
+        storage: Run directory owner.
+        backend: An async-capable capture backend (nodriver).
+        screenshot_label: Label baked into the screenshot filename.
+        console: Optional rich console for user-facing progress.
+    """
+
+    def say(msg: str) -> None:
+        if console is not None:
+            console.print(msg)
+
+    screenshot_data = await backend.take_screenshot()
+    page_source = await backend.get_page_source()
+
+    if screenshot_data is None and page_source is None:
+        say("[yellow]Browser disconnected — screenshot and page source unavailable[/yellow]")
+    else:
+        if screenshot_data:
+            path = storage.save_screenshot(1, screenshot_label, screenshot_data)
+            say(f"[green]Screenshot saved:[/green] {path}")
+        else:
+            say("[yellow]Screenshot capture failed[/yellow]")
+
+        if page_source:
+            source_path = storage.run_dir / "page-source.html"
+            source_path.write_text(page_source, encoding="utf-8")
+            say(f"[green]Page source saved:[/green] {source_path}")
+        else:
+            say("[yellow]Page source capture failed[/yellow]")
+
+    await backend.stop_capture_async()
+
+    har_entries = backend.get_har_entries()
+    if har_entries:
+        storage.write_har(har_entries)
+        say(f"[green]HAR data saved:[/green] {len(har_entries)} entries")
+
+    console_logs = backend.get_console_logs()
+    if console_logs:
+        storage.write_console_logs(console_logs)
+        say(f"[green]Console logs saved:[/green] {len(console_logs)} entries")
+
+    LOG.info(
+        "observe_run_saved",
+        run_dir=str(storage.run_dir),
+        har_entries=len(har_entries),
+        console_logs=len(console_logs),
+    )
+    say(f"\n[bold]Observe run:[/bold] {storage.run_dir}")

--- a/src/graftpunk/observe/run.py
+++ b/src/graftpunk/observe/run.py
@@ -1,9 +1,13 @@
-"""Observe run lifecycle helpers shared by the CLI and the login engine."""
+"""Observe run lifecycle helpers shared by the CLI, BrowserSession and the login engine."""
 
 from __future__ import annotations
 
+import base64
 import datetime
+import json
 import os
+import urllib.parse
+from collections.abc import Iterable
 from typing import Any
 
 from graftpunk.logging import get_logger
@@ -11,10 +15,64 @@ from graftpunk.observe.storage import ObserveStorage
 
 LOG = get_logger(__name__)
 
+REDACTED = "***REDACTED***"
+# Secrets shorter than this are not redacted: replacing every "ab" in a HAR
+# would mangle it beyond use, and such values are not meaningfully secret.
+_MIN_REDACT_LEN = 3
+
 
 def make_run_id() -> str:
     """Return a timestamp+pid run id (unique per process per second)."""
     return datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + f"-{os.getpid()}"
+
+
+def _secret_forms(secret: str) -> set[str]:
+    """Every encoding of ``secret`` that can appear on the wire in a login flow."""
+    return {
+        secret,
+        urllib.parse.quote_plus(secret),
+        urllib.parse.quote(secret, safe=""),
+        json.dumps(secret)[1:-1],
+        base64.b64encode(secret.encode()).decode(),
+    }
+
+
+def redact_har_entries(
+    entries: list[dict[str, Any]], secrets: Iterable[str]
+) -> list[dict[str, Any]]:
+    """Return ``entries`` with every occurrence of ``secrets`` replaced.
+
+    A login run's HAR carries the credentials verbatim: in the form POST body,
+    possibly in a query string, in ``Authorization`` headers, and echoed by
+    some sites into response bodies. Replace each secret -- raw, URL-encoded,
+    JSON-escaped and base64 -- in every string of every entry, longest forms
+    first so a partial encoding does not leave a fragment behind.
+
+    Args:
+        entries: HAR 1.2 entry dicts (not mutated).
+        secrets: Values to remove; empty and very short values are skipped.
+    """
+    forms: set[str] = set()
+    for secret in secrets:
+        if secret and len(secret) >= _MIN_REDACT_LEN:
+            forms |= _secret_forms(secret)
+    if not forms:
+        return entries
+    ordered = sorted(forms, key=len, reverse=True)
+
+    def scrub(value: Any) -> Any:
+        if isinstance(value, str):
+            for form in ordered:
+                if form in value:
+                    value = value.replace(form, REDACTED)
+            return value
+        if isinstance(value, dict):
+            return {k: scrub(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [scrub(v) for v in value]
+        return value
+
+    return scrub(entries)
 
 
 async def save_observe_run(
@@ -23,24 +81,40 @@ async def save_observe_run(
     screenshot_label: str,
     *,
     console: Any | None = None,
+    redact: Iterable[str] = (),
 ) -> None:
     """Persist a nodriver observe run: screenshot, page source, HAR, console logs.
 
     ``backend.stop_capture_async()`` runs after the screenshot/page-source
     grab so the late body fetch happens while the browser is still alive.
-    Progress lines go to ``console`` (a rich Console) when given; otherwise
-    only the log carries them.
+    Each write is guarded on its own so one failure (a full disk, an
+    unserialisable body) cannot take the others down or mask the exception
+    the caller may be unwinding. Progress lines go to ``console`` (a rich
+    Console) when given; the log always carries them.
 
     Args:
         storage: Run directory owner.
         backend: An async-capable capture backend (nodriver).
         screenshot_label: Label baked into the screenshot filename.
         console: Optional rich console for user-facing progress.
+        redact: Secret values (e.g. the submitted credentials) to scrub from
+            the HAR before it is written. Bodies streamed to ``bodies/`` on
+            disk are not scanned.
     """
 
     def say(msg: str) -> None:
         if console is not None:
             console.print(msg)
+
+    def step(name: str, fn: Any) -> Any:
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 — each write is best-effort
+            LOG.error(
+                "observe_run_write_failed", step=name, error=str(exc), exc_type=type(exc).__name__
+            )
+            say(f"[red]{name} failed:[/red] {exc}")
+            return None
 
     screenshot_data = await backend.take_screenshot()
     page_source = await backend.get_page_source()
@@ -49,28 +123,38 @@ async def save_observe_run(
         say("[yellow]Browser disconnected — screenshot and page source unavailable[/yellow]")
     else:
         if screenshot_data:
-            path = storage.save_screenshot(1, screenshot_label, screenshot_data)
-            say(f"[green]Screenshot saved:[/green] {path}")
+            path = step(
+                "screenshot", lambda: storage.save_screenshot(1, screenshot_label, screenshot_data)
+            )
+            if path is not None:
+                say(f"[green]Screenshot saved:[/green] {path}")
         else:
             say("[yellow]Screenshot capture failed[/yellow]")
 
         if page_source:
             source_path = storage.run_dir / "page-source.html"
-            source_path.write_text(page_source, encoding="utf-8")
-            say(f"[green]Page source saved:[/green] {source_path}")
+            if (
+                step("page source", lambda: source_path.write_text(page_source, encoding="utf-8"))
+                is not None
+            ):
+                say(f"[green]Page source saved:[/green] {source_path}")
         else:
             say("[yellow]Page source capture failed[/yellow]")
 
-    await backend.stop_capture_async()
+    try:
+        await backend.stop_capture_async()
+    except Exception as exc:  # noqa: BLE001 — still write what was captured
+        LOG.error("observe_stop_capture_failed", error=str(exc), exc_type=type(exc).__name__)
 
-    har_entries = backend.get_har_entries()
-    if har_entries:
-        storage.write_har(har_entries)
+    har_entries = redact_har_entries(backend.get_har_entries(), redact)
+    if har_entries and step("HAR", lambda: storage.write_har(har_entries)) is not None:
         say(f"[green]HAR data saved:[/green] {len(har_entries)} entries")
 
     console_logs = backend.get_console_logs()
-    if console_logs:
-        storage.write_console_logs(console_logs)
+    if (
+        console_logs
+        and step("console logs", lambda: storage.write_console_logs(console_logs)) is not None
+    ):
         say(f"[green]Console logs saved:[/green] {len(console_logs)} entries")
 
     LOG.info(

--- a/src/graftpunk/plugins/cli_plugin.py
+++ b/src/graftpunk/plugins/cli_plugin.py
@@ -505,6 +505,10 @@ class LoginConfig:
         success: CSS selector for an element indicating login success.
         wait_for: CSS selector to wait for before any steps execute.
             Empty string (default) means no explicit wait.
+        headless: Run the login browser headless. Defaults to False (a visible
+            window) so a human can solve a CAPTCHA or 2FA prompt; set True for
+            sites that need neither. ``gp <plugin> login --headless`` overrides
+            this per invocation.
     """
 
     steps: tuple[LoginStep, ...] | list[LoginStep]  # Always tuple after __post_init__
@@ -512,6 +516,7 @@ class LoginConfig:
     failure: str = ""
     success: str = ""
     wait_for: str = ""
+    headless: bool = False
 
     def __post_init__(self) -> None:
         # Convert list to tuple for immutability and validate each element
@@ -537,6 +542,10 @@ class LoginConfig:
         # Validate success non-whitespace when non-empty
         if self.success and not self.success.strip():
             raise ValueError("LoginConfig.success must not be whitespace")
+        if not isinstance(self.headless, bool):
+            raise TypeError(
+                f"LoginConfig.headless must be bool, got {type(self.headless).__name__}"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -8,6 +8,7 @@ and session caching automatically.
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import time
 import urllib.parse
@@ -33,6 +34,8 @@ _POST_SUBMIT_DELAY = 3  # seconds to wait after form submission for page to sett
 _ELEMENT_WAIT_TIMEOUT = 30  # seconds to wait for element during page transitions
 _ELEMENT_RETRY_INTERVAL = 1.0  # seconds between retry attempts
 _LOGIN_NAV_TIMEOUT = 60  # seconds — login page may redirect through SSO/IdP chains
+_FIELD_SETTLE_DELAY = 0.4  # seconds between send_keys and value read-back (see _fill_field)
+_FIELD_FILL_ATTEMPTS = 3  # select+type attempts before giving up on a field
 
 
 def _resolve_url(base_url: str, url: str) -> str:
@@ -180,6 +183,111 @@ async def _wait_for_element(
         raise PluginError(error_msg) from exc
     if element is None:
         raise PluginError(error_msg)
+
+
+async def _read_field_value(tab: Any, selector: str) -> str | None:
+    """Read an input's current value from the live DOM, by selector.
+
+    Deliberately re-queries the document rather than using the element handle
+    that was typed into: if the page swapped the form, the handle points at a
+    detached node whose value is meaningless.
+
+    Returns:
+        The value as a string, or None if it could not be determined (selector
+        matched nothing, evaluate failed, non-string result). None means
+        "cannot verify", not "empty".
+    """
+    js = (
+        f"(() => {{ const el = document.querySelector({json.dumps(selector)}); "
+        "return el ? el.value : null; })()"
+    )
+    try:
+        result = await tab.evaluate(js, return_by_value=True)
+    except Exception as exc:  # noqa: BLE001 — verification is best-effort
+        LOG.debug("login_field_readback_failed", selector=selector, error=str(exc))
+        return None
+    if isinstance(result, str):
+        return result
+    # nodriver's evaluate(return_by_value=True) returns the RemoteObject itself
+    # when the value is falsy, so an empty string arrives wrapped.
+    value = getattr(result, "value", None)
+    if isinstance(value, str):
+        return value
+    return None
+
+
+async def _fill_field(
+    tab: Any,
+    selector: str,
+    value: str,
+    *,
+    field_name: str,
+    step_idx: int,
+) -> None:
+    """Type ``value`` into the field at ``selector``, verifying it landed.
+
+    Server-rendered sites that re-render the login form shortly after load
+    (jQuery/select2 and friends) turn field filling into a race: the handle
+    from ``_select_with_retry`` can be detached by the time ``send_keys`` runs,
+    the key events dispatch fine, and the characters go nowhere (issue #148).
+
+    After typing, wait ``_FIELD_SETTLE_DELAY`` (Input.dispatchKeyEvent is
+    acknowledged before the renderer updates the value, so an immediate read
+    sees an empty field even on success), then read the value back from the
+    live DOM by selector. On mismatch, re-select, clear, and retype, up to
+    ``_FIELD_FILL_ATTEMPTS`` times. If the value cannot be read back at all,
+    the single fill stands (best-effort verification).
+
+    Raises:
+        PluginError: If the field cannot be found, or never accepts the value.
+    """
+    for attempt in range(1, _FIELD_FILL_ATTEMPTS + 1):
+        element = await _select_with_retry(tab, selector)
+        if element is None:
+            raise PluginError(
+                f"Step {step_idx}: Login field '{field_name}' not found "
+                f"using selector '{selector}'. "
+                "Check your plugin's login step configuration."
+            )
+        await element.click()
+        if attempt > 1:
+            # A late-arriving fill from the previous attempt must not be doubled.
+            await element.clear_input()
+        await element.send_keys(value)
+        if not value:
+            return
+
+        await asyncio.sleep(_FIELD_SETTLE_DELAY)
+        actual = await _read_field_value(tab, selector)
+        if actual is None:
+            LOG.debug("login_field_unverifiable", field=field_name, selector=selector)
+            return
+        if actual == value:
+            if attempt > 1:
+                LOG.info(
+                    "login_field_fill_recovered",
+                    field=field_name,
+                    selector=selector,
+                    attempt=attempt,
+                )
+            return
+        LOG.warning(
+            "login_field_value_mismatch",
+            field=field_name,
+            selector=selector,
+            attempt=attempt,
+            expected_len=len(value),
+            actual_len=len(actual),
+            hint="Typed into a detached node (page re-rendered the form?); re-selecting",
+        )
+
+    raise PluginError(
+        f"Step {step_idx}: Login field '{field_name}' (selector '{selector}') "
+        f"did not accept input after {_FIELD_FILL_ATTEMPTS} attempts. "
+        "The page appears to replace the form after load; the typed value never "
+        "reached the live element. Try a step-level wait_for on the form, or a "
+        "more specific selector."
+    )
 
 
 def _warn_no_login_validation(site_name: str) -> None:
@@ -414,19 +522,13 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
                 if step.wait_for:
                     await _wait_for_element(tab, step.wait_for, f"Step {step_idx}")
 
-                # Fill fields (click before send_keys to prevent keystroke loss)
+                # Fill fields, verifying each value landed (see _fill_field)
                 for field_name, selector in step.fields.items():
                     value = credentials.get(field_name, "")
                     try:
-                        element = await _select_with_retry(tab, selector)
-                        if element is None:
-                            raise PluginError(
-                                f"Step {step_idx}: Login field '{field_name}' not found "
-                                f"using selector '{selector}'. "
-                                "Check your plugin's login step configuration."
-                            )
-                        await element.click()
-                        await element.send_keys(value)
+                        await _fill_field(
+                            tab, selector, value, field_name=field_name, step_idx=step_idx
+                        )
                     except PluginError:
                         raise
                     except Exception as exc:

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -293,6 +293,46 @@ async def _fill_field(
     )
 
 
+def _start_login_capture(
+    plugin: SitePlugin,
+    backend_type: str,
+    driver: Any,
+    observe_mode: str,
+    get_tab: Any = None,
+) -> tuple[Any, Any]:
+    """Create the capture backend for a login run.
+
+    Returns ``(capture, storage)``. With ``observe_mode == "off"`` the capture
+    is the lightweight header-only one used for role extraction and storage is
+    None. Otherwise it is a full capture (bodies streamed to the run dir) and
+    storage is an ``ObserveStorage`` under the plugin's session name, so
+    ``gp --observe=full <plugin> login`` records a run like ``observe go`` does.
+    """
+    from graftpunk.observe.capture import create_capture_backend
+
+    if observe_mode == "off":
+        return create_capture_backend(backend_type, driver, get_tab=get_tab), None
+
+    from graftpunk.observe import OBSERVE_BASE_DIR
+    from graftpunk.observe.run import make_run_id
+    from graftpunk.observe.storage import ObserveStorage
+
+    storage = ObserveStorage(OBSERVE_BASE_DIR, plugin.session_name, make_run_id())
+    capture = create_capture_backend(
+        backend_type,
+        driver,
+        get_tab=get_tab,
+        bodies_dir=storage.run_dir / "bodies",
+    )
+    LOG.info(
+        "login_observe_capture_started",
+        plugin=plugin.site_name,
+        mode=observe_mode,
+        run_dir=str(storage.run_dir),
+    )
+    return capture, storage
+
+
 def _warn_no_login_validation(site_name: str) -> None:
     """Log a warning when no login validation is configured."""
     LOG.warning(
@@ -503,7 +543,22 @@ def generate_login_method(plugin: SitePlugin) -> Any:
 def _generate_nodriver_login(plugin: SitePlugin) -> Any:
     """Generate async login method for nodriver backend."""
 
-    async def login(credentials: dict[str, str]) -> bool:
+    async def login(
+        credentials: dict[str, str],
+        *,
+        headless: bool | None = None,
+        observe_mode: str = "off",
+    ) -> bool:
+        """Log in with a nodriver browser.
+
+        Args:
+            credentials: Field name -> value.
+            headless: Override ``LoginConfig.headless`` for this call; None
+                means use the config value.
+            observe_mode: "off" or "full". "full" records an observe run
+                (screenshot, page source, HAR with bodies, console) under the
+                plugin's session name, whether or not the login succeeds.
+        """
         if plugin.login_config is None:
             raise PluginError(
                 f"Plugin '{plugin.site_name}' has no login configuration. "
@@ -513,10 +568,11 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
         login_url = plugin.login_config.url
         login_target = _resolve_url(base_url, login_url)
         failure_text = plugin.login_config.failure
+        run_headless = plugin.login_config.headless if headless is None else headless
 
         from graftpunk import BrowserSession  # lazy: browser stack ([browser] extra)
 
-        async with BrowserSession(backend="nodriver", headless=False) as session:
+        async with BrowserSession(backend="nodriver", headless=run_headless) as session:
             try:
                 async with asyncio.timeout(_LOGIN_NAV_TIMEOUT):
                     tab = await session.driver.get(login_target)
@@ -533,115 +589,141 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
                     f"URL: {login_target}"
                 ) from None
 
-            # Start header capture for role extraction (lightweight, no body fetching)
-            from graftpunk.observe.capture import create_capture_backend
-
-            _header_capture = create_capture_backend(
-                "nodriver", session.driver, get_tab=lambda: tab
+            # Header capture for role extraction; a full observe run when requested.
+            _header_capture, observe_storage = _start_login_capture(
+                plugin, "nodriver", session.driver, observe_mode, get_tab=lambda: tab
             )
             await _header_capture.start_capture_async()
-
-            # Top-level wait_for: wait for a specific element before any steps
-            # (e.g., a form that appears after a redirect completes)
-            if plugin.login_config.wait_for:
-                await _wait_for_element(tab, plugin.login_config.wait_for, "Login page")
-
-            # Execute each step in sequence: wait_for -> fill fields -> submit -> delay
-            for step_idx, step in enumerate(plugin.login_config.steps, start=1):
-                # Step-level wait_for: wait for element before this step
-                if step.wait_for:
-                    await _wait_for_element(tab, step.wait_for, f"Step {step_idx}")
-
-                # Fill fields, verifying each value landed (see _fill_field)
-                for field_name, selector in step.fields.items():
-                    value = credentials.get(field_name, "")
-                    try:
-                        await _fill_field(
-                            tab, selector, value, field_name=field_name, step_idx=step_idx
-                        )
-                    except PluginError:
-                        raise
-                    except Exception as exc:
-                        raise PluginError(
-                            f"Step {step_idx}: Failed to fill login field '{field_name}' "
-                            f"(selector: '{selector}'): {exc}"
-                        ) from exc
-
-                # Click submit if specified for this step
-                if step.submit:
-                    try:
-                        submit = await _select_with_retry(tab, step.submit)
-                        if submit is None:
-                            raise PluginError(
-                                f"Step {step_idx}: Submit button not found "
-                                f"using selector '{step.submit}'. "
-                                "Check your plugin's login step configuration."
-                            )
-                        await submit.click()
-                    except PluginError:
-                        raise
-                    except Exception as exc:
-                        raise PluginError(
-                            f"Step {step_idx}: Failed to click submit button "
-                            f"(selector: '{step.submit}'): {exc}"
-                        ) from exc
-
-                # Step-level delay after submit
-                if step.delay > 0:
-                    await asyncio.sleep(step.delay)
-
-            # Fixed delay to allow page to settle after all steps complete
-            await asyncio.sleep(_POST_SUBMIT_DELAY)
-
-            # Check success/failure
-            page_text = await tab.get_content()
-            success_selector = plugin.login_config.success
-            success_found: bool | None = None
-            if success_selector:
-                # Bare select (no retry): page has settled after submit delay;
-                # retrying here would mask genuine login failures.
-                success_element = await tab.select(success_selector)
-                success_found = success_element is not None
-
-            if not _check_login_result(
-                page_text=page_text,
-                failure_text=failure_text,
-                success_found=success_found,
-                success_selector=success_selector or "",
-                site_name=plugin.site_name,
-            ):
-                return False
-
-            # Capture current URL before caching (used for domain display)
             try:
-                if tab and hasattr(tab, "url"):
-                    session.current_url = tab.url or login_target
-                else:
-                    session.current_url = login_target
-            except Exception as exc:  # noqa: BLE001 — URL is optional metadata for display
-                LOG.debug("login_url_capture_failed", error=str(exc), backend="nodriver")
-                session.current_url = login_target
-
-            # Extract header roles from captured network requests
-            session._gp_header_roles = _header_capture.get_header_roles()
-
-            # Transfer cookies and cache
-            await session.transfer_nodriver_cookies_to_session()
-
-            # Extract tokens using the already-open browser (avoids separate launch)
-            try:
-                await _extract_and_cache_tokens_nodriver(plugin, session, tab, base_url)
-            except Exception as exc:  # noqa: BLE001 — best-effort; login already succeeded
-                LOG.warning(
-                    "login_token_extraction_failed",
-                    plugin=plugin.site_name,
-                    error=str(exc),
+                return await _run_nodriver_steps(
+                    plugin=plugin,
+                    session=session,
+                    tab=tab,
+                    credentials=credentials,
+                    login_target=login_target,
+                    failure_text=failure_text,
+                    base_url=base_url,
+                    header_capture=_header_capture,
                 )
+            finally:
+                if observe_storage is not None:
+                    from graftpunk.observe.run import save_observe_run
 
-            cache_session(session, plugin.session_name)
-            return True
+                    await save_observe_run(observe_storage, _header_capture, "login")
 
     return login
+
+
+async def _run_nodriver_steps(
+    *,
+    plugin: SitePlugin,
+    session: Any,
+    tab: Any,
+    credentials: dict[str, str],
+    login_target: str,
+    failure_text: str,
+    base_url: str,
+    header_capture: Any,
+) -> bool:
+    """Execute the configured login steps on an open tab and cache on success."""
+    assert plugin.login_config is not None  # noqa: S101 — checked by caller
+    # Top-level wait_for: wait for a specific element before any steps
+    # (e.g., a form that appears after a redirect completes)
+    if plugin.login_config.wait_for:
+        await _wait_for_element(tab, plugin.login_config.wait_for, "Login page")
+
+    # Execute each step in sequence: wait_for -> fill fields -> submit -> delay
+    for step_idx, step in enumerate(plugin.login_config.steps, start=1):
+        # Step-level wait_for: wait for element before this step
+        if step.wait_for:
+            await _wait_for_element(tab, step.wait_for, f"Step {step_idx}")
+
+        # Fill fields, verifying each value landed (see _fill_field)
+        for field_name, selector in step.fields.items():
+            value = credentials.get(field_name, "")
+            try:
+                await _fill_field(tab, selector, value, field_name=field_name, step_idx=step_idx)
+            except PluginError:
+                raise
+            except Exception as exc:
+                raise PluginError(
+                    f"Step {step_idx}: Failed to fill login field '{field_name}' "
+                    f"(selector: '{selector}'): {exc}"
+                ) from exc
+
+        # Click submit if specified for this step
+        if step.submit:
+            try:
+                submit = await _select_with_retry(tab, step.submit)
+                if submit is None:
+                    raise PluginError(
+                        f"Step {step_idx}: Submit button not found "
+                        f"using selector '{step.submit}'. "
+                        "Check your plugin's login step configuration."
+                    )
+                await submit.click()
+            except PluginError:
+                raise
+            except Exception as exc:
+                raise PluginError(
+                    f"Step {step_idx}: Failed to click submit button "
+                    f"(selector: '{step.submit}'): {exc}"
+                ) from exc
+
+        # Step-level delay after submit
+        if step.delay > 0:
+            await asyncio.sleep(step.delay)
+
+    # Fixed delay to allow page to settle after all steps complete
+    await asyncio.sleep(_POST_SUBMIT_DELAY)
+
+    # Check success/failure
+    page_text = await tab.get_content()
+    success_selector = plugin.login_config.success
+    success_found: bool | None = None
+    if success_selector:
+        # Bare select (no retry): page has settled after submit delay;
+        # retrying here would mask genuine login failures.
+        success_element = await tab.select(success_selector)
+        success_found = success_element is not None
+
+    if not _check_login_result(
+        page_text=page_text,
+        failure_text=failure_text,
+        success_found=success_found,
+        success_selector=success_selector or "",
+        site_name=plugin.site_name,
+    ):
+        return False
+
+    # Capture current URL before caching (used for domain display)
+    try:
+        if tab and hasattr(tab, "url"):
+            session.current_url = tab.url or login_target
+        else:
+            session.current_url = login_target
+    except Exception as exc:  # noqa: BLE001 — URL is optional metadata for display
+        LOG.debug("login_url_capture_failed", error=str(exc), backend="nodriver")
+        session.current_url = login_target
+
+    # Extract header roles from captured network requests
+    session._gp_header_roles = header_capture.get_header_roles()
+
+    # Transfer cookies and cache
+    await session.transfer_nodriver_cookies_to_session()
+
+    # Extract tokens using the already-open browser (avoids separate launch)
+    try:
+        await _extract_and_cache_tokens_nodriver(plugin, session, tab, base_url)
+    except Exception as exc:  # noqa: BLE001 — best-effort; login already succeeded
+        LOG.warning(
+            "login_token_extraction_failed",
+            plugin=plugin.site_name,
+            error=str(exc),
+        )
+
+    cache_session(session, plugin.session_name)
+    return True
 
 
 def _generate_selenium_login(plugin: SitePlugin) -> Any:
@@ -649,7 +731,22 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
     import selenium.common.exceptions
     from selenium.common.exceptions import NoSuchElementException
 
-    def login(credentials: dict[str, str]) -> bool:
+    def login(
+        credentials: dict[str, str],
+        *,
+        headless: bool | None = None,
+        observe_mode: str = "off",
+    ) -> bool:
+        """Log in with a selenium browser.
+
+        Args:
+            credentials: Field name -> value.
+            headless: Override ``LoginConfig.headless`` for this call; None
+                means use the config value.
+            observe_mode: "off" or "full". "full" makes the BrowserSession
+                record an observe run (HAR, console, error screenshot) under
+                the plugin's session name.
+        """
         if plugin.login_config is None:
             raise PluginError(
                 f"Plugin '{plugin.site_name}' has no login configuration. "
@@ -660,15 +757,26 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
         login_target = _resolve_url(base_url, login_url)
         failure_text = plugin.login_config.failure
         success_selector = plugin.login_config.success
+        run_headless = plugin.login_config.headless if headless is None else headless
 
         from graftpunk import BrowserSession  # lazy: browser stack ([browser] extra)
 
-        with BrowserSession(backend="selenium", headless=False) as session:
-            # Start header capture for role extraction
-            from graftpunk.observe.capture import create_capture_backend
+        # BrowserSession owns observe for selenium (its capture drains Chrome's
+        # performance log, which is single-consumer), so hand it the mode and
+        # the session name the run should be filed under.
+        browser_session = BrowserSession(
+            backend="selenium", headless=run_headless, observe_mode=observe_mode
+        )
+        browser_session._session_name = plugin.session_name
+        with browser_session as session:
+            # Header capture for role extraction: reuse the session's observe
+            # capture when it has one, else start a lightweight one.
+            _header_capture = getattr(session, "_capture", None) if observe_mode != "off" else None
+            if _header_capture is None:
+                from graftpunk.observe.capture import create_capture_backend
 
-            _header_capture = create_capture_backend("selenium", session.driver)
-            _header_capture.start_capture()
+                _header_capture = create_capture_backend("selenium", session.driver)
+                _header_capture.start_capture()
 
             session.driver.get(login_target)
 

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -435,9 +435,12 @@ def _check_login_result(
     """
     lowered = page_text.lower()
 
-    # Checked first: a rate-limited response is a page from the site's limiter,
-    # not a verdict on the credentials, and it never contains the success element.
-    if any(marker in lowered for marker in _RATE_LIMIT_MARKERS):
+    # A rate-limited response is a page from the site's limiter, not a verdict
+    # on the credentials. It never contains the success element, so a found
+    # success element always wins: page_text is raw HTML, and an inlined i18n
+    # bundle or error catalogue on a real post-login page can contain the
+    # marker text. Only refine a failure, never veto a success.
+    if success_found is not True and any(marker in lowered for marker in _RATE_LIMIT_MARKERS):
         LOG.warning(
             "login_rate_limited",
             plugin=site_name,

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -630,9 +630,15 @@ def generate_login_method(plugin: SitePlugin) -> Any:
     # removes duplication between the two generators.
     backend = getattr(plugin, "backend", "selenium")
 
-    if backend == "nodriver":
-        return _generate_nodriver_login(plugin)
-    return _generate_selenium_login(plugin)
+    login = (
+        _generate_nodriver_login(plugin)
+        if backend == "nodriver"
+        else _generate_selenium_login(plugin)
+    )
+    # Lets the CLI tell a generated login from a plugin's hand-written one
+    # (help text, which options to offer) without inspecting docstrings.
+    login._gp_generated_login = True
+    return login
 
 
 def _generate_nodriver_login(plugin: SitePlugin) -> Any:

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -195,28 +195,60 @@ async def _read_field_value(tab: Any, selector: str) -> str | None:
     that was typed into: if the page swapped the form, the handle points at a
     detached node whose value is meaningless.
 
+    The page-side expression always returns a JSON string, so nodriver's
+    ``evaluate(return_by_value=True)`` quirk (a falsy value comes back as the
+    RemoteObject itself) never applies.
+
     Returns:
-        The value as a string, or None if it could not be determined (selector
-        matched nothing, evaluate failed, non-string result). None means
-        "cannot verify", not "empty".
+        The value as a string. ``""`` when the selector matches nothing in the
+        live document (the field is not there to hold a value). ``None`` only
+        when the read itself failed (evaluate raised, JS threw, unparseable
+        result) -- "cannot verify", which callers must not confuse with
+        "empty".
     """
     js = (
         f"(() => {{ const el = document.querySelector({json.dumps(selector)}); "
-        "return el ? el.value : null; })()"
+        "return JSON.stringify({found: !!el, value: el ? String(el.value) : null}); })()"
     )
     try:
         result = await tab.evaluate(js, return_by_value=True)
     except Exception as exc:  # noqa: BLE001 — verification is best-effort
         LOG.debug("login_field_readback_failed", selector=selector, error=str(exc))
         return None
-    if isinstance(result, str):
-        return result
-    # nodriver's evaluate(return_by_value=True) returns the RemoteObject itself
-    # when the value is falsy, so an empty string arrives wrapped.
-    value = getattr(result, "value", None)
-    if isinstance(value, str):
-        return value
-    return None
+    if not isinstance(result, str):
+        # nodriver returns ExceptionDetails when the JS throws.
+        LOG.debug(
+            "login_field_readback_unparseable",
+            selector=selector,
+            result_type=type(result).__name__,
+            detail=getattr(result, "text", None),
+        )
+        return None
+    try:
+        data = json.loads(result)
+    except ValueError:
+        LOG.debug("login_field_readback_unparseable", selector=selector, result_type="str")
+        return None
+    if not isinstance(data, dict) or not data.get("found"):
+        LOG.debug("login_field_selector_vanished", selector=selector)
+        return ""
+    value = data.get("value")
+    return value if isinstance(value, str) else None
+
+
+async def _clear_field(element: Any, tab: Any, selector: str) -> None:
+    """Empty the field and make sure it stayed empty.
+
+    Keystrokes from a previous attempt can flush after the renderer lag that
+    the settle delay exists for; if the read-back is non-empty right after
+    clearing, clear once more so nothing is doubled (issue #148 measured that
+    doubled text is a worse failure than an empty field).
+    """
+    await element.clear_input()
+    current = await _read_field_value(tab, selector)
+    if current:
+        LOG.debug("login_field_clear_repeated", selector=selector, residual_len=len(current))
+        await element.clear_input()
 
 
 async def _fill_field(
@@ -234,16 +266,27 @@ async def _fill_field(
     from ``_select_with_retry`` can be detached by the time ``send_keys`` runs,
     the key events dispatch fine, and the characters go nowhere (issue #148).
 
-    After typing, wait ``_FIELD_SETTLE_DELAY`` (Input.dispatchKeyEvent is
-    acknowledged before the renderer updates the value, so an immediate read
-    sees an empty field even on success), then read the value back from the
-    live DOM by selector. On mismatch, re-select, clear, and retype, up to
-    ``_FIELD_FILL_ATTEMPTS`` times. If the value cannot be read back at all,
-    the single fill stands (best-effort verification).
+    Each attempt re-selects the element, clears it, types, waits
+    ``_FIELD_SETTLE_DELAY`` (Input.dispatchKeyEvent is acknowledged before the
+    renderer updates the value, so an immediate read sees an empty field even
+    on success), then reads the value back from the live DOM by selector.
+    Interacting with a detached handle can also raise (click/clear resolve the
+    backend node); that counts as a failed attempt, not a terminal error.
+
+    Outcomes after ``_FIELD_FILL_ATTEMPTS``:
+
+    - value read back equals ``value``: done.
+    - read-back is non-empty but different: the site normalises input
+      (lowercasing, masks, autocomplete). Warn and proceed; the browser's own
+      validation still guards a genuinely empty required field.
+    - read-back is empty (or the selector no longer matches anything): the
+      typed value never reached the live element. Raise.
+    - read-back impossible: the single fill stands (best-effort verification).
 
     Raises:
         PluginError: If the field cannot be found, or never accepts the value.
     """
+    last_actual: str | None = None
     for attempt in range(1, _FIELD_FILL_ATTEMPTS + 1):
         element = await _select_with_retry(tab, selector)
         if element is None:
@@ -252,11 +295,23 @@ async def _fill_field(
                 f"using selector '{selector}'. "
                 "Check your plugin's login step configuration."
             )
-        await element.click()
-        if attempt > 1:
-            # A late-arriving fill from the previous attempt must not be doubled.
-            await element.clear_input()
-        await element.send_keys(value)
+        try:
+            await element.click()
+            await _clear_field(element, tab, selector)
+            await element.send_keys(value)
+        except Exception as exc:
+            if attempt == _FIELD_FILL_ATTEMPTS:
+                raise
+            LOG.warning(
+                "login_field_interaction_failed",
+                field=field_name,
+                selector=selector,
+                attempt=attempt,
+                error=str(exc),
+                exc_type=type(exc).__name__,
+                hint="Element handle may be detached (page re-rendered the form?); re-selecting",
+            )
+            continue
         if not value:
             return
 
@@ -274,6 +329,7 @@ async def _fill_field(
                     attempt=attempt,
                 )
             return
+        last_actual = actual
         LOG.warning(
             "login_field_value_mismatch",
             field=field_name,
@@ -283,6 +339,20 @@ async def _fill_field(
             actual_len=len(actual),
             hint="Typed into a detached node (page re-rendered the form?); re-selecting",
         )
+
+    if last_actual:
+        LOG.warning(
+            "login_field_value_normalized",
+            field=field_name,
+            selector=selector,
+            expected_len=len(value),
+            actual_len=len(last_actual),
+            hint=(
+                "The field holds a non-empty value that differs from what was typed; "
+                "the site appears to normalise input. Proceeding with the fill."
+            ),
+        )
+        return
 
     raise PluginError(
         f"Step {step_idx}: Login field '{field_name}' (selector '{selector}') "

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -36,6 +36,9 @@ _ELEMENT_RETRY_INTERVAL = 1.0  # seconds between retry attempts
 _LOGIN_NAV_TIMEOUT = 60  # seconds — login page may redirect through SSO/IdP chains
 _FIELD_SETTLE_DELAY = 0.4  # seconds between send_keys and value read-back (see _fill_field)
 _FIELD_FILL_ATTEMPTS = 3  # select+type attempts before giving up on a field
+# Page text that identifies a rate-limited response (HTTP 429 body) rather than
+# a login outcome. Matched case-insensitively against the post-submit page.
+_RATE_LIMIT_MARKERS = ("too many requests",)
 
 
 def _resolve_url(base_url: str, url: str) -> str:
@@ -320,8 +323,31 @@ def _check_login_result(
     Returns:
         True if login appears successful, False if it failed.
     """
-    if failure_text and failure_text.lower() in page_text.lower():
-        LOG.warning("login_failure_text_detected", plugin=site_name, text=failure_text)
+    lowered = page_text.lower()
+
+    # Checked first: a rate-limited response is a page from the site's limiter,
+    # not a verdict on the credentials, and it never contains the success element.
+    if any(marker in lowered for marker in _RATE_LIMIT_MARKERS):
+        LOG.warning(
+            "login_rate_limited",
+            plugin=site_name,
+            hint=(
+                "The site returned a 'Too Many Requests' page. This is not a "
+                "credentials problem; wait before retrying."
+            ),
+        )
+        return False
+
+    if failure_text and failure_text.lower() in lowered:
+        LOG.warning(
+            "login_failure_text_detected",
+            plugin=site_name,
+            text=failure_text,
+            hint=(
+                "The configured failure text is on the page. Sites show it for "
+                "wrong credentials, but also for an empty or malformed submission."
+            ),
+        )
         return False
 
     if success_found is False:
@@ -329,6 +355,10 @@ def _check_login_result(
             "login_success_element_not_found",
             plugin=site_name,
             selector=success_selector,
+            hint=(
+                "The page never showed the configured success element. The login "
+                "may still be on the form, or the site may have redirected elsewhere."
+            ),
         )
         return False
 

--- a/src/graftpunk/plugins/login_engine.py
+++ b/src/graftpunk/plugins/login_engine.py
@@ -15,6 +15,7 @@ import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from graftpunk import cache_session
+from graftpunk import console as gp_console
 from graftpunk.exceptions import PluginError
 from graftpunk.logging import get_logger
 
@@ -383,11 +384,32 @@ def _start_login_capture(
     if observe_mode == "off":
         return create_capture_backend(backend_type, driver, get_tab=get_tab), None
 
+    # Why the login engine owns this for nodriver instead of handing
+    # observe_mode to BrowserSession like the selenium path: the nodriver
+    # capture needs a get_tab callable for the tab that the login opens, and
+    # its eager body fetch only runs from start_capture_async(), neither of
+    # which BrowserSession's sync _start_observe can provide.
+    import slugify as slugify_lib
+
     from graftpunk.observe import OBSERVE_BASE_DIR
     from graftpunk.observe.run import make_run_id
     from graftpunk.observe.storage import ObserveStorage
 
-    storage = ObserveStorage(OBSERVE_BASE_DIR, plugin.session_name, make_run_id())
+    # Opt-in diagnostics must never break the login: an unsafe session name or
+    # an unwritable base dir degrades to the header-only capture with a warning.
+    session_slug = slugify_lib.slugify(plugin.session_name) or "default"
+    try:
+        storage = ObserveStorage(OBSERVE_BASE_DIR, session_slug, make_run_id())
+    except (ValueError, OSError) as exc:
+        LOG.warning(
+            "login_observe_unavailable",
+            plugin=plugin.site_name,
+            session_name=session_slug,
+            error=str(exc),
+            exc_type=type(exc).__name__,
+        )
+        gp_console.warn(f"Observability capture unavailable for this login: {exc}")
+        return create_capture_backend(backend_type, driver, get_tab=get_tab), None
     capture = create_capture_backend(
         backend_type,
         driver,
@@ -682,7 +704,24 @@ def _generate_nodriver_login(plugin: SitePlugin) -> Any:
                 if observe_storage is not None:
                     from graftpunk.observe.run import save_observe_run
 
-                    await save_observe_run(observe_storage, _header_capture, "login")
+                    # Never let a storage problem replace the login outcome
+                    # (or the PluginError being unwound) with a disk error.
+                    try:
+                        await save_observe_run(
+                            observe_storage,
+                            _header_capture,
+                            "login",
+                            console=gp_console.err_console,
+                            redact=credentials.values(),
+                        )
+                    except Exception as exc:  # noqa: BLE001 — diagnostics are best-effort
+                        LOG.error(
+                            "login_observe_save_failed",
+                            plugin=plugin.site_name,
+                            run_dir=str(observe_storage.run_dir),
+                            error=str(exc),
+                            exc_type=type(exc).__name__,
+                        )
 
     return login
 
@@ -840,11 +879,13 @@ def _generate_selenium_login(plugin: SitePlugin) -> Any:
         browser_session = BrowserSession(
             backend="selenium", headless=run_headless, observe_mode=observe_mode
         )
-        browser_session._session_name = plugin.session_name
+        browser_session.session_name = plugin.session_name
+        # The observe HAR carries the login POST; scrub the credentials.
+        browser_session.observe_redact = credentials.values()
         with browser_session as session:
             # Header capture for role extraction: reuse the session's observe
             # capture when it has one, else start a lightweight one.
-            _header_capture = getattr(session, "_capture", None) if observe_mode != "off" else None
+            _header_capture = session.capture if observe_mode != "off" else None
             if _header_capture is None:
                 from graftpunk.observe.capture import create_capture_backend
 

--- a/src/graftpunk/plugins/yaml_loader.py
+++ b/src/graftpunk/plugins/yaml_loader.py
@@ -388,12 +388,18 @@ def parse_yaml_plugin(
                     f"Plugin '{filepath}': login step #{i + 1} is invalid: {exc}"
                 ) from exc
 
+        headless = login_block.get("headless", False)
+        if not isinstance(headless, bool):
+            raise PluginError(
+                f"Plugin '{filepath}': login.headless must be true or false, got {headless!r}."
+            )
         login_config = LoginConfig(
             steps=steps,
             url=login_block.get("url", ""),
             wait_for=login_block.get("wait_for", ""),
             failure=login_block.get("failure", ""),
             success=login_block.get("success", ""),
+            headless=headless,
         )
 
     # Parse token config

--- a/src/graftpunk/session.py
+++ b/src/graftpunk/session.py
@@ -21,7 +21,6 @@ Example:
 """
 
 import asyncio
-import os
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -114,6 +113,7 @@ class BrowserSession(requestium.Session):
         self._observe_mode = observe_mode
         self._capture: Any = None
         self._observe_storage: ObserveStorage | None = None
+        self._observe_redact: tuple[str, ...] = ()
 
         if backend == "nodriver":
             # Use nodriver backend directly (CDP-based, no ChromeDriver)
@@ -223,6 +223,20 @@ class BrowserSession(requestium.Session):
             value: Session name to set.
         """
         self._session_name = value
+
+    @property
+    def capture(self) -> Any | None:
+        """The observe capture backend, or None when observe is off / not started."""
+        return self._capture
+
+    @property
+    def observe_redact(self) -> tuple[str, ...]:
+        """Secret values scrubbed from the observe HAR before it is written."""
+        return self._observe_redact
+
+    @observe_redact.setter
+    def observe_redact(self, values: Any) -> None:
+        self._observe_redact = tuple(str(v) for v in values if v)
 
     @property
     def driver(self) -> Any:
@@ -351,11 +365,25 @@ class BrowserSession(requestium.Session):
                 f"Requested mode '{self._observe_mode}' will have no effect."
             )
             return
-        import datetime
+        from graftpunk.observe.run import make_run_id
 
-        run_id = datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + f"-{os.getpid()}"
-        session_name = getattr(self, "_session_name", "default")
-        self._observe_storage = ObserveStorage(OBSERVE_BASE_DIR, session_name, run_id)
+        run_id = make_run_id()
+        # Storage requires a filesystem-safe name; a plugin's session_name is
+        # only validated non-empty. Opt-in diagnostics must never break the
+        # primary operation, so slugify and fall back to no capture on error.
+        session_name = slugify_lib.slugify(getattr(self, "_session_name", "default")) or "default"
+        try:
+            self._observe_storage = ObserveStorage(OBSERVE_BASE_DIR, session_name, run_id)
+        except (ValueError, OSError) as exc:
+            LOG.warning(
+                "observe_start_skipped_storage_error",
+                session_name=session_name,
+                error=str(exc),
+                exc_type=type(exc).__name__,
+            )
+            gp_console.warn(f"Observability capture unavailable: {exc}")
+            self._observe_storage = None
+            return
         self._capture = create_capture_backend(self._backend_type, driver)
         self._capture.start_capture()
         LOG.info("observe_capture_started", mode=self._observe_mode, run_id=run_id)
@@ -377,8 +405,16 @@ class BrowserSession(requestium.Session):
         """Write HAR and console logs to storage."""
         if self._observe_storage is None or self._capture is None:
             return
+        from graftpunk.observe.run import redact_har_entries
+
         try:
-            self._observe_storage.write_har(self._capture.get_har_entries())
+            # getattr: sessions restored via __setstate__ or built without
+            # __init__ (tests) may predate the attribute.
+            self._observe_storage.write_har(
+                redact_har_entries(
+                    self._capture.get_har_entries(), getattr(self, "_observe_redact", ())
+                )
+            )
         except Exception as exc:
             LOG.error("observe_har_write_failed", error=str(exc), exc_type=type(exc).__name__)
         try:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,3 +63,4 @@ def _fast_login_timings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("graftpunk.plugins.login_engine._ELEMENT_WAIT_TIMEOUT", 0.05)
     monkeypatch.setattr("graftpunk.plugins.login_engine._ELEMENT_RETRY_INTERVAL", 0.001)
     monkeypatch.setattr("graftpunk.plugins.login_engine._LOGIN_NAV_TIMEOUT", 0.05)
+    monkeypatch.setattr("graftpunk.plugins.login_engine._FIELD_SETTLE_DELAY", 0.001)

--- a/tests/unit/test_login_engine.py
+++ b/tests/unit/test_login_engine.py
@@ -742,6 +742,22 @@ class TestCheckLoginResult:
         events = [c.args[0] for c in mock_log.warning.call_args_list]
         assert events == ["login_rate_limited"]
 
+    def test_rate_limit_marker_never_vetoes_a_found_success_element(self) -> None:
+        """page_text is raw HTML; a post-login page's inlined JS can contain the
+        marker. A found success element is the stronger signal."""
+        from graftpunk.plugins.login_engine import _check_login_result
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            result = _check_login_result(
+                page_text='<script>i18n={"e429":"Too many requests"}</script><div id=dash>',
+                failure_text="Bad login.",
+                success_found=True,
+                success_selector="#dash",
+                site_name="test",
+            )
+        assert result is True
+        mock_log.warning.assert_not_called()
+
     def test_rate_limit_detection_is_case_insensitive(self) -> None:
         from graftpunk.plugins.login_engine import _check_login_result
 

--- a/tests/unit/test_login_engine.py
+++ b/tests/unit/test_login_engine.py
@@ -726,6 +726,51 @@ class TestNodriverLoginValidationPaths:
 class TestCheckLoginResult:
     """Direct tests for _check_login_result()."""
 
+    def test_rate_limited_page_returns_false_and_logs_rate_limit(self) -> None:
+        """A 'Too Many Requests' page is not a credentials failure (issue #148 item 2)."""
+        from graftpunk.plugins.login_engine import _check_login_result
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            result = _check_login_result(
+                page_text="<html><title>429 Too Many Requests</title></html>",
+                failure_text="These credentials do not match",
+                success_found=False,
+                success_selector="#dashboard",
+                site_name="test",
+            )
+        assert result is False
+        events = [c.args[0] for c in mock_log.warning.call_args_list]
+        assert events == ["login_rate_limited"]
+
+    def test_rate_limit_detection_is_case_insensitive(self) -> None:
+        from graftpunk.plugins.login_engine import _check_login_result
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            result = _check_login_result(
+                page_text="<h1>TOO MANY REQUESTS</h1>",
+                failure_text="",
+                success_found=None,
+                success_selector="",
+                site_name="test",
+            )
+        assert result is False
+        assert mock_log.warning.call_args.args[0] == "login_rate_limited"
+
+    def test_failure_warning_carries_still_on_login_page_hint(self) -> None:
+        """The failure-text warning must not read as a credentials verdict."""
+        from graftpunk.plugins.login_engine import _check_login_result
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            _check_login_result(
+                page_text="<html>Bad login.</html>",
+                failure_text="Bad login.",
+                success_found=None,
+                success_selector="",
+                site_name="test",
+            )
+        kwargs = mock_log.warning.call_args.kwargs
+        assert "hint" in kwargs
+
     def test_failure_text_present_returns_false(self) -> None:
         """Returns False when failure text is found in page text (case-insensitive)."""
         from graftpunk.plugins.login_engine import _check_login_result

--- a/tests/unit/test_login_engine.py
+++ b/tests/unit/test_login_engine.py
@@ -1710,10 +1710,11 @@ class TestNodriverMultiStepLogin:
             result = await login_method({"username": "user", "password": "pass"})  # noqa: S106
 
         assert result is True
-        # Exactly two sleep calls: step delay (0.5) and post-submit delay (patched to 0)
+        # Four sleep calls: one settle per filled field (2, from _fill_field),
+        # the step delay (0.5), and the post-submit delay (patched to ~0).
         from graftpunk.plugins.login_engine import _POST_SUBMIT_DELAY
 
-        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_count == 4
         sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
         assert 0.5 in sleep_calls
         assert _POST_SUBMIT_DELAY in sleep_calls

--- a/tests/unit/test_login_field_fill.py
+++ b/tests/unit/test_login_field_fill.py
@@ -6,10 +6,13 @@ by the time ``send_keys`` runs. nodriver dispatches the key events happily, the
 characters go nowhere, and nothing raises. ``_fill_field`` reads the value back
 *by selector* (not via the handle) after a settle delay, and re-selects and
 retypes on mismatch.
+
+Read-back protocol: the page-side JS returns ``JSON.stringify({found, value})``.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,9 +20,19 @@ import pytest
 
 from graftpunk.exceptions import PluginError
 from graftpunk.plugins import login_engine
-from graftpunk.plugins.login_engine import _fill_field
+from graftpunk.plugins.login_engine import _fill_field, _read_field_value
 
 pytestmark = pytest.mark.usefixtures("_fast_login_timings")
+
+N = login_engine._FIELD_FILL_ATTEMPTS
+
+
+def _rb(value: str) -> str:
+    """A read-back result for a present element holding ``value``."""
+    return json.dumps({"found": True, "value": value})
+
+
+_MISSING = json.dumps({"found": False, "value": None})
 
 
 def _make_element() -> AsyncMock:
@@ -27,7 +40,12 @@ def _make_element() -> AsyncMock:
 
 
 def _make_tab(elements: list[Any], readbacks: list[Any]) -> MagicMock:
-    """Tab whose select() yields ``elements`` in order and evaluate() yields ``readbacks``."""
+    """Tab whose select() yields ``elements`` in order and evaluate() yields ``readbacks``.
+
+    Each attempt reads back twice: once after clearing (must be empty) and
+    once after typing (must equal the value); an empty ``value`` skips the
+    second read.
+    """
     tab = MagicMock()
     tab.select = AsyncMock(side_effect=elements)
     tab.evaluate = AsyncMock(side_effect=readbacks)
@@ -38,38 +56,42 @@ class TestFillFieldHappyPath:
     @pytest.mark.asyncio
     async def test_value_verified_first_attempt_types_once(self) -> None:
         element = _make_element()
-        tab = _make_tab([element], ["alice@example.com"])
+        tab = _make_tab([element], [_rb(""), _rb("alice@example.com")])
 
         await _fill_field(
             tab, "input[name=email]", "alice@example.com", field_name="email", step_idx=1
         )
 
         element.click.assert_awaited_once()
+        element.clear_input.assert_awaited_once()  # every attempt starts from empty
         element.send_keys.assert_awaited_once_with("alice@example.com")
-        element.clear_input.assert_not_awaited()
         assert tab.select.await_count == 1
 
     @pytest.mark.asyncio
     async def test_readback_queries_dom_by_selector_not_handle(self) -> None:
         """The check must ask the *document* what the field holds, not the stale handle."""
         element = _make_element()
-        tab = _make_tab([element], ["secret"])
+        tab = _make_tab([element], [_rb(""), _rb("secret")])
 
         await _fill_field(tab, "#pw", "secret", field_name="password", step_idx=1)
 
         js = tab.evaluate.await_args.args[0]
         assert "querySelector" in js
         assert '"#pw"' in js
+        assert "JSON.stringify" in js
         assert tab.evaluate.await_args.kwargs.get("return_by_value") is True
 
     @pytest.mark.asyncio
-    async def test_settle_delay_precedes_readback(self) -> None:
+    async def test_settle_delay_precedes_verification_readback(self) -> None:
         """Input.dispatchKeyEvent is acked before the DOM updates; read too early and
         even a successful fill looks empty (issue #148 gotcha)."""
         element = _make_element()
-        tab = _make_tab([element], ["v"])
         order: list[str] = []
-        tab.evaluate = AsyncMock(side_effect=lambda *a, **k: order.append("read") or "v")
+        tab = MagicMock()
+        tab.select = AsyncMock(return_value=element)
+        reads = iter([_rb(""), _rb("v")])
+        tab.evaluate = AsyncMock(side_effect=lambda *a, **k: order.append("read") or next(reads))
+        element.send_keys = AsyncMock(side_effect=lambda v: order.append("type"))
 
         async def fake_sleep(delay: float) -> None:
             order.append(f"sleep:{delay}")
@@ -77,17 +99,28 @@ class TestFillFieldHappyPath:
         with patch("graftpunk.plugins.login_engine.asyncio.sleep", side_effect=fake_sleep):
             await _fill_field(tab, "#f", "v", field_name="f", step_idx=1)
 
-        assert order == [f"sleep:{login_engine._FIELD_SETTLE_DELAY}", "read"]
+        assert order == ["read", "type", f"sleep:{login_engine._FIELD_SETTLE_DELAY}", "read"]
 
     @pytest.mark.asyncio
     async def test_empty_value_skips_verification(self) -> None:
         element = _make_element()
-        tab = _make_tab([element], [])
+        tab = _make_tab([element], [_rb("")])
 
         await _fill_field(tab, "#f", "", field_name="f", step_idx=1)
 
         element.send_keys.assert_awaited_once_with("")
-        tab.evaluate.assert_not_awaited()
+        assert tab.evaluate.await_count == 1  # only the post-clear check
+
+    @pytest.mark.asyncio
+    async def test_prefilled_field_is_cleared_before_typing(self) -> None:
+        """A browser-remembered value must not be appended to."""
+        element = _make_element()
+        tab = _make_tab([element], [_rb(""), _rb("alice")])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        assert element.clear_input.await_count == 1
+        assert element.send_keys.await_count == 1
 
 
 class TestFillFieldStaleNodeRecovery:
@@ -95,21 +128,19 @@ class TestFillFieldStaleNodeRecovery:
     async def test_stale_handle_is_reselected_and_retyped(self) -> None:
         """First handle was detached (readback empty); second select gets the live node."""
         stale, live = _make_element(), _make_element()
-        tab = _make_tab([stale, live], ["", "alice"])
+        tab = _make_tab([stale, live], [_rb(""), _rb(""), _rb(""), _rb("alice")])
 
         await _fill_field(tab, "input[name=email]", "alice", field_name="email", step_idx=1)
 
         assert tab.select.await_count == 2
         stale.send_keys.assert_awaited_once_with("alice")
         live.send_keys.assert_awaited_once_with("alice")
-        # The retry clears first so a late-arriving partial fill is not doubled.
-        stale.clear_input.assert_not_awaited()
         live.clear_input.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_partial_value_triggers_retry(self) -> None:
         first, second = _make_element(), _make_element()
-        tab = _make_tab([first, second], ["ali", "alice"])
+        tab = _make_tab([first, second], [_rb(""), _rb("ali"), _rb(""), _rb("alice")])
 
         await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
 
@@ -117,9 +148,21 @@ class TestFillFieldStaleNodeRecovery:
         second.send_keys.assert_awaited_once_with("alice")
 
     @pytest.mark.asyncio
-    async def test_gives_up_with_clear_error_after_max_attempts(self) -> None:
-        elements = [_make_element() for _ in range(login_engine._FIELD_FILL_ATTEMPTS)]
-        tab = _make_tab(elements, [""] * login_engine._FIELD_FILL_ATTEMPTS)
+    async def test_late_keystrokes_after_clear_are_cleared_again(self) -> None:
+        """A previous attempt's characters can flush after the clear; never type on
+        top of them (doubled text submits as something that looks deliberate)."""
+        element = _make_element()
+        tab = _make_tab([element], [_rb("stray"), _rb("alice")])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        assert element.clear_input.await_count == 2
+        element.send_keys.assert_awaited_once_with("alice")
+
+    @pytest.mark.asyncio
+    async def test_gives_up_with_clear_error_when_value_never_lands(self) -> None:
+        elements = [_make_element() for _ in range(N)]
+        tab = _make_tab(elements, [_rb("")] * (2 * N))
 
         with pytest.raises(PluginError) as excinfo:
             await _fill_field(tab, "input[name=email]", "alice", field_name="email", step_idx=2)
@@ -130,7 +173,55 @@ class TestFillFieldStaleNodeRecovery:
         assert "input[name=email]" in msg
         assert "did not accept input" in msg
         assert "alice" not in msg  # never leak the credential
-        assert tab.select.await_count == login_engine._FIELD_FILL_ATTEMPTS
+        assert tab.select.await_count == N
+
+    @pytest.mark.asyncio
+    async def test_selector_vanishing_after_select_is_a_failure_not_unverifiable(self) -> None:
+        """The form was re-rendered into a shape the selector cannot address: the
+        silent empty submit from #148. Must not be accepted."""
+        elements = [_make_element() for _ in range(N)]
+        tab = _make_tab(elements, [_MISSING] * (2 * N))
+
+        with pytest.raises(PluginError, match="did not accept input"):
+            await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+    @pytest.mark.asyncio
+    async def test_non_empty_but_different_value_proceeds_with_warning(self) -> None:
+        """Sites that lowercase, trim or mask input hold a value that differs from
+        what was typed; that is not the detached-node bug and must not fail login."""
+        elements = [_make_element() for _ in range(N)]
+        tab = _make_tab(elements, [_rb(""), _rb("alice")] * N)
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            await _fill_field(tab, "#e", "Alice", field_name="email", step_idx=1)
+
+        events = [c.args[0] for c in mock_log.warning.call_args_list]
+        assert events[-1] == "login_field_value_normalized"
+        assert tab.select.await_count == N
+
+    @pytest.mark.asyncio
+    async def test_interaction_exception_is_retried(self) -> None:
+        """click/clear on a detached handle can raise; that is an attempt, not the end."""
+        stale, live = _make_element(), _make_element()
+        stale.click = AsyncMock(side_effect=RuntimeError("Could not find node with given id"))
+        tab = _make_tab([stale, live], [_rb(""), _rb("alice")])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        live.send_keys.assert_awaited_once_with("alice")
+        assert tab.select.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_interaction_exception_on_final_attempt_propagates(self) -> None:
+        elements = [_make_element() for _ in range(N)]
+        for el in elements:
+            el.click = AsyncMock(side_effect=RuntimeError("node gone"))
+        tab = _make_tab(elements, [])
+
+        with pytest.raises(RuntimeError, match="node gone"):
+            await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        assert tab.select.await_count == N
 
     @pytest.mark.asyncio
     async def test_element_missing_on_first_select_raises_not_found(self) -> None:
@@ -141,9 +232,9 @@ class TestFillFieldStaleNodeRecovery:
             await _fill_field(tab, "#gone", "x", field_name="user", step_idx=1)
 
     @pytest.mark.asyncio
-    async def test_mismatch_log_never_contains_value(self) -> None:
+    async def test_logs_never_contain_the_value(self) -> None:
         stale, live = _make_element(), _make_element()
-        tab = _make_tab([stale, live], ["", "hunter2"])
+        tab = _make_tab([stale, live], [_rb(""), _rb(""), _rb(""), _rb("hunter2")])
 
         with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
             await _fill_field(tab, "#pw", "hunter2", field_name="password", step_idx=1)
@@ -152,42 +243,60 @@ class TestFillFieldStaleNodeRecovery:
             assert "hunter2" not in repr(call)
 
 
-class TestFillFieldReadback:
+class TestReadFieldValue:
+    @pytest.mark.asyncio
+    async def test_present_element_returns_value(self) -> None:
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(return_value=_rb("alice"))
+        assert await _read_field_value(tab, "#e") == "alice"
+
+    @pytest.mark.asyncio
+    async def test_empty_value_is_empty_string_not_none(self) -> None:
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(return_value=_rb(""))
+        assert await _read_field_value(tab, "#e") == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_element_is_empty_string(self) -> None:
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(return_value=_MISSING)
+        assert await _read_field_value(tab, "#e") == ""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_raising_is_none(self) -> None:
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(side_effect=RuntimeError("evaluate unavailable"))
+        assert await _read_field_value(tab, "#e") is None
+
+    @pytest.mark.asyncio
+    async def test_exception_details_object_is_none_and_logged(self) -> None:
+        """nodriver returns an ExceptionDetails object (not a str) when the JS throws."""
+        details = MagicMock()
+        details.text = "Uncaught"
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(return_value=details)
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            assert await _read_field_value(tab, "#e") is None
+
+        assert mock_log.debug.call_args.args[0] == "login_field_readback_unparseable"
+        assert mock_log.debug.call_args.kwargs["detail"] == "Uncaught"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_string_is_none(self) -> None:
+        tab = MagicMock()
+        tab.evaluate = AsyncMock(return_value="not json")
+        assert await _read_field_value(tab, "#e") is None
+
+
+class TestFillFieldUnverifiable:
     @pytest.mark.asyncio
     async def test_readback_error_is_best_effort_no_retry(self) -> None:
         """If the value cannot be read back (evaluate raises), keep the single fill."""
         element = _make_element()
-        tab = _make_tab([element], [RuntimeError("evaluate unavailable")])
+        tab = _make_tab([element], [RuntimeError("no"), RuntimeError("no")])
 
         await _fill_field(tab, "#f", "v", field_name="f", step_idx=1)
 
         assert tab.select.await_count == 1
         element.send_keys.assert_awaited_once_with("v")
-
-    @pytest.mark.asyncio
-    async def test_remote_object_with_empty_value_counts_as_empty(self) -> None:
-        """nodriver's evaluate(return_by_value=True) returns the RemoteObject itself
-        when the value is falsy, so '' arrives wrapped."""
-        remote = MagicMock()
-        remote.value = ""
-        remote.type_ = "string"
-        stale, live = _make_element(), _make_element()
-        tab = _make_tab([stale, live], [remote, "alice"])
-
-        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
-
-        assert tab.select.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_non_string_readback_is_unverifiable(self) -> None:
-        """A null result (selector matched nothing at read time) cannot be verified;
-        do not loop on it."""
-        remote = MagicMock()
-        remote.value = None
-        remote.type_ = "object"
-        element = _make_element()
-        tab = _make_tab([element], [remote])
-
-        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
-
-        assert tab.select.await_count == 1

--- a/tests/unit/test_login_field_fill.py
+++ b/tests/unit/test_login_field_fill.py
@@ -1,0 +1,193 @@
+"""Tests for _fill_field: verify-and-retype so typing into a detached node is caught.
+
+Issue #148: on a page that re-renders its login form shortly after load, the
+element handle resolved by ``_select_with_retry`` can be detached from the DOM
+by the time ``send_keys`` runs. nodriver dispatches the key events happily, the
+characters go nowhere, and nothing raises. ``_fill_field`` reads the value back
+*by selector* (not via the handle) after a settle delay, and re-selects and
+retypes on mismatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graftpunk.exceptions import PluginError
+from graftpunk.plugins import login_engine
+from graftpunk.plugins.login_engine import _fill_field
+
+pytestmark = pytest.mark.usefixtures("_fast_login_timings")
+
+
+def _make_element() -> AsyncMock:
+    return AsyncMock()
+
+
+def _make_tab(elements: list[Any], readbacks: list[Any]) -> MagicMock:
+    """Tab whose select() yields ``elements`` in order and evaluate() yields ``readbacks``."""
+    tab = MagicMock()
+    tab.select = AsyncMock(side_effect=elements)
+    tab.evaluate = AsyncMock(side_effect=readbacks)
+    return tab
+
+
+class TestFillFieldHappyPath:
+    @pytest.mark.asyncio
+    async def test_value_verified_first_attempt_types_once(self) -> None:
+        element = _make_element()
+        tab = _make_tab([element], ["alice@example.com"])
+
+        await _fill_field(
+            tab, "input[name=email]", "alice@example.com", field_name="email", step_idx=1
+        )
+
+        element.click.assert_awaited_once()
+        element.send_keys.assert_awaited_once_with("alice@example.com")
+        element.clear_input.assert_not_awaited()
+        assert tab.select.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_readback_queries_dom_by_selector_not_handle(self) -> None:
+        """The check must ask the *document* what the field holds, not the stale handle."""
+        element = _make_element()
+        tab = _make_tab([element], ["secret"])
+
+        await _fill_field(tab, "#pw", "secret", field_name="password", step_idx=1)
+
+        js = tab.evaluate.await_args.args[0]
+        assert "querySelector" in js
+        assert '"#pw"' in js
+        assert tab.evaluate.await_args.kwargs.get("return_by_value") is True
+
+    @pytest.mark.asyncio
+    async def test_settle_delay_precedes_readback(self) -> None:
+        """Input.dispatchKeyEvent is acked before the DOM updates; read too early and
+        even a successful fill looks empty (issue #148 gotcha)."""
+        element = _make_element()
+        tab = _make_tab([element], ["v"])
+        order: list[str] = []
+        tab.evaluate = AsyncMock(side_effect=lambda *a, **k: order.append("read") or "v")
+
+        async def fake_sleep(delay: float) -> None:
+            order.append(f"sleep:{delay}")
+
+        with patch("graftpunk.plugins.login_engine.asyncio.sleep", side_effect=fake_sleep):
+            await _fill_field(tab, "#f", "v", field_name="f", step_idx=1)
+
+        assert order == [f"sleep:{login_engine._FIELD_SETTLE_DELAY}", "read"]
+
+    @pytest.mark.asyncio
+    async def test_empty_value_skips_verification(self) -> None:
+        element = _make_element()
+        tab = _make_tab([element], [])
+
+        await _fill_field(tab, "#f", "", field_name="f", step_idx=1)
+
+        element.send_keys.assert_awaited_once_with("")
+        tab.evaluate.assert_not_awaited()
+
+
+class TestFillFieldStaleNodeRecovery:
+    @pytest.mark.asyncio
+    async def test_stale_handle_is_reselected_and_retyped(self) -> None:
+        """First handle was detached (readback empty); second select gets the live node."""
+        stale, live = _make_element(), _make_element()
+        tab = _make_tab([stale, live], ["", "alice"])
+
+        await _fill_field(tab, "input[name=email]", "alice", field_name="email", step_idx=1)
+
+        assert tab.select.await_count == 2
+        stale.send_keys.assert_awaited_once_with("alice")
+        live.send_keys.assert_awaited_once_with("alice")
+        # The retry clears first so a late-arriving partial fill is not doubled.
+        stale.clear_input.assert_not_awaited()
+        live.clear_input.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_partial_value_triggers_retry(self) -> None:
+        first, second = _make_element(), _make_element()
+        tab = _make_tab([first, second], ["ali", "alice"])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        second.clear_input.assert_awaited_once()
+        second.send_keys.assert_awaited_once_with("alice")
+
+    @pytest.mark.asyncio
+    async def test_gives_up_with_clear_error_after_max_attempts(self) -> None:
+        elements = [_make_element() for _ in range(login_engine._FIELD_FILL_ATTEMPTS)]
+        tab = _make_tab(elements, [""] * login_engine._FIELD_FILL_ATTEMPTS)
+
+        with pytest.raises(PluginError) as excinfo:
+            await _fill_field(tab, "input[name=email]", "alice", field_name="email", step_idx=2)
+
+        msg = str(excinfo.value)
+        assert "Step 2" in msg
+        assert "email" in msg
+        assert "input[name=email]" in msg
+        assert "did not accept input" in msg
+        assert "alice" not in msg  # never leak the credential
+        assert tab.select.await_count == login_engine._FIELD_FILL_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_element_missing_on_first_select_raises_not_found(self) -> None:
+        tab = _make_tab([], [])
+        tab.select = AsyncMock(return_value=None)
+
+        with pytest.raises(PluginError, match="not found"):
+            await _fill_field(tab, "#gone", "x", field_name="user", step_idx=1)
+
+    @pytest.mark.asyncio
+    async def test_mismatch_log_never_contains_value(self) -> None:
+        stale, live = _make_element(), _make_element()
+        tab = _make_tab([stale, live], ["", "hunter2"])
+
+        with patch("graftpunk.plugins.login_engine.LOG") as mock_log:
+            await _fill_field(tab, "#pw", "hunter2", field_name="password", step_idx=1)
+
+        for call in mock_log.method_calls:
+            assert "hunter2" not in repr(call)
+
+
+class TestFillFieldReadback:
+    @pytest.mark.asyncio
+    async def test_readback_error_is_best_effort_no_retry(self) -> None:
+        """If the value cannot be read back (evaluate raises), keep the single fill."""
+        element = _make_element()
+        tab = _make_tab([element], [RuntimeError("evaluate unavailable")])
+
+        await _fill_field(tab, "#f", "v", field_name="f", step_idx=1)
+
+        assert tab.select.await_count == 1
+        element.send_keys.assert_awaited_once_with("v")
+
+    @pytest.mark.asyncio
+    async def test_remote_object_with_empty_value_counts_as_empty(self) -> None:
+        """nodriver's evaluate(return_by_value=True) returns the RemoteObject itself
+        when the value is falsy, so '' arrives wrapped."""
+        remote = MagicMock()
+        remote.value = ""
+        remote.type_ = "string"
+        stale, live = _make_element(), _make_element()
+        tab = _make_tab([stale, live], [remote, "alice"])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        assert tab.select.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_string_readback_is_unverifiable(self) -> None:
+        """A null result (selector matched nothing at read time) cannot be verified;
+        do not loop on it."""
+        remote = MagicMock()
+        remote.value = None
+        remote.type_ = "object"
+        element = _make_element()
+        tab = _make_tab([element], [remote])
+
+        await _fill_field(tab, "#e", "alice", field_name="email", step_idx=1)
+
+        assert tab.select.await_count == 1

--- a/tests/unit/test_login_headless_observe.py
+++ b/tests/unit/test_login_headless_observe.py
@@ -392,12 +392,34 @@ class TestEngineObserve:
 
 
 class TestLoginCommandPlumbing:
-    def test_login_command_exposes_headless_flag(self) -> None:
+    def test_generated_login_exposes_headless_and_headful_flags(self) -> None:
         from graftpunk.cli.login_commands import create_login_fn
 
         plugin = _make_plugin("nodriver")
         fn = create_login_fn(plugin, generate_login_method(plugin), {"username": "#u"})
-        assert "headless" in inspect.signature(fn).parameters
+        params = [p for p in inspect.signature(fn).parameters if p != "ctx"]
+        assert params == ["headless", "headful"]
+
+    def test_generated_login_help_names_the_site_not_the_engine(self) -> None:
+        from graftpunk.cli.login_commands import create_login_fn
+
+        plugin = _make_plugin("nodriver")
+        fn = create_login_fn(plugin, generate_login_method(plugin), {"username": "#u"})
+        assert fn.__doc__ == "Log in to hl"
+
+    def test_hand_written_login_gets_no_flags_it_cannot_honour(self) -> None:
+        from graftpunk.cli.login_commands import create_login_fn
+
+        plugin = _make_plugin("nodriver")
+
+        def login(credentials: dict[str, str]) -> bool:
+            """Sign in to Example."""
+            return True
+
+        fn = create_login_fn(plugin, login, {"username": "#u"})
+        params = [p for p in inspect.signature(fn).parameters if p != "ctx"]
+        assert params == []
+        assert fn.__doc__ == "Sign in to Example."
 
     def _run_body(self, login: Any, ctx: Any, **kwargs: Any) -> None:
         from graftpunk.cli.login_commands import make_login_body
@@ -405,37 +427,53 @@ class TestLoginCommandPlumbing:
         body = make_login_body(SimpleNamespace(site_name="acme"), login, {"username": "#u"})
         body(ctx, **kwargs)
 
+    @staticmethod
+    def _recording_login(seen: dict[str, Any]) -> Any:
+        def login(
+            credentials: dict[str, str], *, headless: bool | None = None, observe_mode: str = "off"
+        ) -> bool:
+            seen.update(headless=headless, observe_mode=observe_mode)
+            return True
+
+        return login
+
     def test_passes_headless_and_observe_to_declarative_login(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("ACME_USERNAME", "u")
         seen: dict[str, Any] = {}
-
-        def login(
-            credentials: dict[str, str], *, headless: bool | None = None, observe_mode: str = "off"
-        ) -> bool:
-            seen.update(headless=headless, observe_mode=observe_mode)
-            return True
-
         root = SimpleNamespace(obj={"observe_mode": "full"})
         ctx = SimpleNamespace(find_root=lambda: root)
-        self._run_body(login, ctx, headless=True)
+
+        self._run_body(self._recording_login(seen), ctx, headless=True, headful=False)
 
         assert seen == {"headless": True, "observe_mode": "full"}
 
-    def test_flag_unset_means_use_config(self, monkeypatch: Any) -> None:
+    def test_headful_forces_a_window(self, monkeypatch: Any) -> None:
+        """A plugin with headless: true still needs an escape hatch for CAPTCHA/2FA."""
         monkeypatch.setenv("ACME_USERNAME", "u")
         seen: dict[str, Any] = {}
+        ctx = SimpleNamespace(find_root=lambda: SimpleNamespace(obj={}))
 
-        def login(
-            credentials: dict[str, str], *, headless: bool | None = None, observe_mode: str = "off"
-        ) -> bool:
-            seen.update(headless=headless, observe_mode=observe_mode)
-            return True
+        self._run_body(self._recording_login(seen), ctx, headless=False, headful=True)
 
-        root = SimpleNamespace(obj={})
-        ctx = SimpleNamespace(find_root=lambda: root)
-        self._run_body(login, ctx, headless=False)
+        assert seen["headless"] is False
+
+    def test_no_flag_means_use_config(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ACME_USERNAME", "u")
+        seen: dict[str, Any] = {}
+        ctx = SimpleNamespace(find_root=lambda: SimpleNamespace(obj={}))
+
+        self._run_body(self._recording_login(seen), ctx, headless=False, headful=False)
 
         assert seen == {"headless": None, "observe_mode": "off"}
+
+    def test_both_flags_is_a_usage_error(self, monkeypatch: Any) -> None:
+        import typer
+
+        monkeypatch.setenv("ACME_USERNAME", "u")
+        ctx = SimpleNamespace(find_root=lambda: SimpleNamespace(obj={}))
+
+        with pytest.raises(typer.BadParameter):
+            self._run_body(self._recording_login({}), ctx, headless=True, headful=True)
 
     def test_user_defined_login_without_kwargs_still_works(self, monkeypatch: Any) -> None:
         """A plugin's own login(credentials) must not receive kwargs it never declared."""
@@ -448,9 +486,28 @@ class TestLoginCommandPlumbing:
 
         root = SimpleNamespace(obj={"observe_mode": "full"})
         ctx = SimpleNamespace(find_root=lambda: root)
-        self._run_body(login, ctx, headless=True)
+        self._run_body(login, ctx)
 
         assert calls == [{"username": "u"}]
+
+    def test_required_positional_of_same_name_is_not_fed_the_flag(self) -> None:
+        from graftpunk.cli.login_commands import _accepted_login_kwargs
+
+        def login(credentials: dict[str, str], headless: bool) -> bool:
+            return True
+
+        assert _accepted_login_kwargs(login, headless=None, observe_mode="off") == {}
+
+    def test_var_keyword_accepts_everything(self) -> None:
+        from graftpunk.cli.login_commands import _accepted_login_kwargs
+
+        def login(credentials: dict[str, str], **kw: Any) -> bool:
+            return True
+
+        assert _accepted_login_kwargs(login, headless=None, observe_mode="off") == {
+            "headless": None,
+            "observe_mode": "off",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_login_headless_observe.py
+++ b/tests/unit/test_login_headless_observe.py
@@ -1,0 +1,389 @@
+"""Tests for LoginConfig.headless / ``login --headless`` and ``--observe=full`` on login.
+
+Issue #148 items 3 and 4: declarative login hardcoded ``headless=False`` with no
+override, and ``--observe=full`` produced no observe run for ``<plugin> login``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graftpunk.exceptions import PluginError
+from graftpunk.plugins.cli_plugin import LoginConfig, LoginStep, SitePlugin
+from graftpunk.plugins.login_engine import generate_login_method
+
+pytestmark = pytest.mark.usefixtures("_fast_login_timings")
+
+
+@pytest.fixture(autouse=True)
+def _mock_capture_backend():
+    """Default header capture mock; tests that assert on the factory re-patch it."""
+    capture = MagicMock()
+    capture.start_capture_async = AsyncMock()
+    capture.get_header_roles = MagicMock(return_value={})
+    with patch("graftpunk.observe.capture.create_capture_backend", return_value=capture):
+        yield capture
+
+
+def _make_plugin(backend: str, *, headless: bool = False) -> SitePlugin:
+    class P(SitePlugin):
+        site_name = "hl"
+        session_name = "hl-session"
+        help_text = "t"
+        base_url = "https://example.com"
+
+    P.backend = backend  # type: ignore[assignment]
+    P.login_config = LoginConfig(
+        steps=[LoginStep(fields={"username": "#u", "password": "#p"}, submit="#s")],
+        url="/login",
+        failure="Bad login.",
+        headless=headless,
+    )
+    return P()
+
+
+def _nodriver_session_mock(tab: MagicMock) -> tuple[MagicMock, MagicMock]:
+    mock_bs = MagicMock()
+    instance = MagicMock()
+    mock_bs.return_value = instance
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=False)
+    instance.driver = MagicMock()
+    instance.driver.get = AsyncMock(return_value=tab)
+    instance.transfer_nodriver_cookies_to_session = AsyncMock()
+    return mock_bs, instance
+
+
+def _nodriver_tab(page: str = "<html>Bad login.</html>") -> MagicMock:
+    tab = MagicMock()
+    tab.select = AsyncMock(return_value=AsyncMock())
+    tab.get_content = AsyncMock(return_value=page)
+    return tab
+
+
+def _selenium_session_mock() -> tuple[MagicMock, MagicMock]:
+    mock_bs = MagicMock()
+    instance = MagicMock()
+    mock_bs.return_value = instance
+    instance.__enter__ = MagicMock(return_value=instance)
+    instance.__exit__ = MagicMock(return_value=False)
+    instance.driver = MagicMock()
+    instance.driver.page_source = "<html>Bad login.</html>"
+    instance._capture = None
+    return mock_bs, instance
+
+
+# ---------------------------------------------------------------------------
+# LoginConfig.headless
+# ---------------------------------------------------------------------------
+
+
+class TestLoginConfigHeadless:
+    def test_defaults_to_headful(self) -> None:
+        cfg = LoginConfig(steps=[LoginStep(fields={"u": "#u"})])
+        assert cfg.headless is False
+
+    def test_accepts_true(self) -> None:
+        cfg = LoginConfig(steps=[LoginStep(fields={"u": "#u"})], headless=True)
+        assert cfg.headless is True
+
+    def test_rejects_non_bool(self) -> None:
+        with pytest.raises(TypeError, match="headless"):
+            LoginConfig(steps=[LoginStep(fields={"u": "#u"})], headless="yes")  # type: ignore[arg-type]
+
+
+class TestYamlHeadless:
+    def _parse(self, tmp_path: Path, extra: str) -> Any:
+        from graftpunk.plugins.yaml_loader import parse_yaml_plugin
+
+        yaml_file = tmp_path / "p.yaml"
+        yaml_file.write_text(
+            f"""
+site_name: mysite
+base_url: "https://example.com"
+login:
+  url: "/login"
+{extra}
+  steps:
+    - fields:
+        username: "input#email"
+      submit: "button"
+commands:
+  search:
+    url: "/api/search"
+"""
+        )
+        config, _, _ = parse_yaml_plugin(yaml_file)
+        return config
+
+    def test_headless_true(self, tmp_path: Path) -> None:
+        config = self._parse(tmp_path, "  headless: true")
+        assert config.login_config.headless is True
+
+    def test_headless_defaults_false(self, tmp_path: Path) -> None:
+        config = self._parse(tmp_path, "")
+        assert config.login_config.headless is False
+
+    def test_headless_non_bool_is_plugin_error(self, tmp_path: Path) -> None:
+        with pytest.raises(PluginError, match="headless"):
+            self._parse(tmp_path, '  headless: "yes"')
+
+
+# ---------------------------------------------------------------------------
+# Engine honours headless
+# ---------------------------------------------------------------------------
+
+
+class TestEngineHeadless:
+    @pytest.mark.asyncio
+    async def test_nodriver_default_is_headful(self) -> None:
+        tab = _nodriver_tab()
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver"))
+
+        with patch("graftpunk.BrowserSession", mock_bs):
+            await login({"username": "u", "password": "p"})
+
+        assert mock_bs.call_args.kwargs["headless"] is False
+
+    @pytest.mark.asyncio
+    async def test_nodriver_config_headless(self) -> None:
+        tab = _nodriver_tab()
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver", headless=True))
+
+        with patch("graftpunk.BrowserSession", mock_bs):
+            await login({"username": "u", "password": "p"})
+
+        assert mock_bs.call_args.kwargs["headless"] is True
+
+    @pytest.mark.asyncio
+    async def test_nodriver_call_override_beats_config(self) -> None:
+        tab = _nodriver_tab()
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver", headless=False))
+
+        with patch("graftpunk.BrowserSession", mock_bs):
+            await login({"username": "u", "password": "p"}, headless=True)
+
+        assert mock_bs.call_args.kwargs["headless"] is True
+
+    def test_selenium_config_headless(self) -> None:
+        mock_bs, _ = _selenium_session_mock()
+        login = generate_login_method(_make_plugin("selenium", headless=True))
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.plugins.login_engine.time"),
+        ):
+            login({"username": "u", "password": "p"})
+
+        assert mock_bs.call_args.kwargs["headless"] is True
+
+    def test_selenium_call_override(self) -> None:
+        mock_bs, _ = _selenium_session_mock()
+        login = generate_login_method(_make_plugin("selenium", headless=False))
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.plugins.login_engine.time"),
+        ):
+            login({"username": "u", "password": "p"}, headless=True)
+
+        assert mock_bs.call_args.kwargs["headless"] is True
+
+
+# ---------------------------------------------------------------------------
+# --observe=full covers login
+# ---------------------------------------------------------------------------
+
+
+class TestEngineObserve:
+    @pytest.mark.asyncio
+    async def test_nodriver_observe_off_creates_no_run(self, tmp_path: Path) -> None:
+        tab = _nodriver_tab()
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver"))
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch("graftpunk.observe.run.save_observe_run", new_callable=AsyncMock) as save,
+        ):
+            await login({"username": "u", "password": "p"})
+
+        save.assert_not_awaited()
+        assert not (tmp_path / "hl-session").exists()
+
+    @pytest.mark.asyncio
+    async def test_nodriver_observe_full_saves_run_even_on_failed_login(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed login is exactly the run worth capturing."""
+        tab = _nodriver_tab("<html>Bad login.</html>")
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver"))
+        mock_capture = MagicMock()
+        mock_capture.start_capture_async = AsyncMock()
+        mock_capture.get_header_roles = MagicMock(return_value={})
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch(
+                "graftpunk.observe.capture.create_capture_backend", return_value=mock_capture
+            ) as ccb,
+            patch("graftpunk.observe.run.save_observe_run", new_callable=AsyncMock) as save,
+        ):
+            result = await login({"username": "u", "password": "p"}, observe_mode="full")
+
+        assert result is False
+        save.assert_awaited_once()
+        storage, backend, label = save.await_args.args
+        assert backend is mock_capture
+        assert label == "login"
+        assert storage.run_dir.parent.parent == tmp_path
+        assert storage.run_dir.parent.name == "hl-session"
+        # Full capture: bodies go to the run dir, not the header-only capture.
+        assert ccb.call_args.kwargs["bodies_dir"] == storage.run_dir / "bodies"
+
+    @pytest.mark.asyncio
+    async def test_nodriver_observe_full_saves_run_on_exception(self, tmp_path: Path) -> None:
+        tab = _nodriver_tab()
+        tab.select = AsyncMock(return_value=None)  # field never found -> PluginError
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver"))
+        mock_capture = MagicMock()
+        mock_capture.start_capture_async = AsyncMock()
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch("graftpunk.observe.capture.create_capture_backend", return_value=mock_capture),
+            patch("graftpunk.observe.run.save_observe_run", new_callable=AsyncMock) as save,
+            pytest.raises(PluginError),
+        ):
+            await login({"username": "u", "password": "p"}, observe_mode="full")
+
+        save.assert_awaited_once()
+
+    def test_selenium_observe_full_uses_session_capture(self, tmp_path: Path) -> None:
+        """Selenium: BrowserSession owns observe (perf-log drain is single-consumer),
+        so login must pass observe_mode through and reuse the session's capture for
+        header roles rather than starting a second one."""
+        mock_bs, instance = _selenium_session_mock()
+        session_capture = MagicMock()
+        session_capture.get_header_roles = MagicMock(return_value={"x": {}})
+        instance._capture = session_capture
+        login = generate_login_method(_make_plugin("selenium"))
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.plugins.login_engine.time"),
+            patch("graftpunk.observe.capture.create_capture_backend") as ccb,
+        ):
+            login({"username": "u", "password": "p"}, observe_mode="full")
+
+        assert mock_bs.call_args.kwargs["observe_mode"] == "full"
+        assert instance._session_name == "hl-session"
+        ccb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestLoginCommandPlumbing:
+    def test_login_command_exposes_headless_flag(self) -> None:
+        from graftpunk.cli.login_commands import create_login_fn
+
+        plugin = _make_plugin("nodriver")
+        fn = create_login_fn(plugin, generate_login_method(plugin), {"username": "#u"})
+        assert "headless" in inspect.signature(fn).parameters
+
+    def _run_body(self, login: Any, ctx: Any, **kwargs: Any) -> None:
+        from graftpunk.cli.login_commands import make_login_body
+
+        body = make_login_body(SimpleNamespace(site_name="acme"), login, {"username": "#u"})
+        body(ctx, **kwargs)
+
+    def test_passes_headless_and_observe_to_declarative_login(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ACME_USERNAME", "u")
+        seen: dict[str, Any] = {}
+
+        def login(
+            credentials: dict[str, str], *, headless: bool | None = None, observe_mode: str = "off"
+        ) -> bool:
+            seen.update(headless=headless, observe_mode=observe_mode)
+            return True
+
+        root = SimpleNamespace(obj={"observe_mode": "full"})
+        ctx = SimpleNamespace(find_root=lambda: root)
+        self._run_body(login, ctx, headless=True)
+
+        assert seen == {"headless": True, "observe_mode": "full"}
+
+    def test_flag_unset_means_use_config(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ACME_USERNAME", "u")
+        seen: dict[str, Any] = {}
+
+        def login(
+            credentials: dict[str, str], *, headless: bool | None = None, observe_mode: str = "off"
+        ) -> bool:
+            seen.update(headless=headless, observe_mode=observe_mode)
+            return True
+
+        root = SimpleNamespace(obj={})
+        ctx = SimpleNamespace(find_root=lambda: root)
+        self._run_body(login, ctx, headless=False)
+
+        assert seen == {"headless": None, "observe_mode": "off"}
+
+    def test_user_defined_login_without_kwargs_still_works(self, monkeypatch: Any) -> None:
+        """A plugin's own login(credentials) must not receive kwargs it never declared."""
+        monkeypatch.setenv("ACME_USERNAME", "u")
+        calls: list[dict[str, str]] = []
+
+        def login(credentials: dict[str, str]) -> bool:
+            calls.append(credentials)
+            return True
+
+        root = SimpleNamespace(obj={"observe_mode": "full"})
+        ctx = SimpleNamespace(find_root=lambda: root)
+        self._run_body(login, ctx, headless=True)
+
+        assert calls == [{"username": "u"}]
+
+
+# ---------------------------------------------------------------------------
+# save_observe_run
+# ---------------------------------------------------------------------------
+
+
+class TestSaveObserveRun:
+    @pytest.mark.asyncio
+    async def test_writes_screenshot_source_har_and_console(self, tmp_path: Path) -> None:
+        from graftpunk.observe.run import save_observe_run
+        from graftpunk.observe.storage import ObserveStorage
+
+        storage = ObserveStorage(tmp_path, "sess", "run1")
+        backend = MagicMock()
+        backend.take_screenshot = AsyncMock(return_value=b"\\x89PNG")
+        backend.get_page_source = AsyncMock(return_value="<html/>")
+        backend.stop_capture_async = AsyncMock()
+        backend.get_har_entries = MagicMock(return_value=[{"request": {}, "response": {}}])
+        backend.get_console_logs = MagicMock(return_value=[{"level": "log"}])
+
+        await save_observe_run(storage, backend, "login")
+
+        backend.stop_capture_async.assert_awaited_once()
+        assert (storage.run_dir / "page-source.html").read_text() == "<html/>"
+        assert list((storage.run_dir / "screenshots").glob("*login*.png"))
+        assert any(p.suffix == ".har" for p in storage.run_dir.iterdir())

--- a/tests/unit/test_login_headless_observe.py
+++ b/tests/unit/test_login_headless_observe.py
@@ -7,6 +7,7 @@ override, and ``--observe=full`` produced no observe run for ``<plugin> login``.
 from __future__ import annotations
 
 import inspect
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -61,8 +62,20 @@ def _nodriver_session_mock(tab: MagicMock) -> tuple[MagicMock, MagicMock]:
 
 
 def _nodriver_tab(page: str = "<html>Bad login.</html>") -> MagicMock:
+    """Tab with a stateful fake field: send_keys appends, clear_input empties,
+    evaluate reads back what the field holds, so _fill_field's verification
+    runs for real instead of silently taking the "unverifiable" branch."""
+    state = {"value": ""}
+    element = AsyncMock()
+    element.send_keys = AsyncMock(
+        side_effect=lambda v: state.__setitem__("value", state["value"] + v)
+    )
+    element.clear_input = AsyncMock(side_effect=lambda: state.__setitem__("value", ""))
     tab = MagicMock()
-    tab.select = AsyncMock(return_value=AsyncMock())
+    tab.select = AsyncMock(return_value=element)
+    tab.evaluate = AsyncMock(
+        side_effect=lambda *a, **k: json.dumps({"found": True, "value": state["value"]})
+    )
     tab.get_content = AsyncMock(return_value=page)
     return tab
 

--- a/tests/unit/test_login_headless_observe.py
+++ b/tests/unit/test_login_headless_observe.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from graftpunk.exceptions import PluginError
+from graftpunk.observe.capture import create_capture_backend as _real_create_capture_backend
 from graftpunk.plugins.cli_plugin import LoginConfig, LoginStep, SitePlugin
 from graftpunk.plugins.login_engine import generate_login_method
 
@@ -88,7 +89,7 @@ def _selenium_session_mock() -> tuple[MagicMock, MagicMock]:
     instance.__exit__ = MagicMock(return_value=False)
     instance.driver = MagicMock()
     instance.driver.page_source = "<html>Bad login.</html>"
-    instance._capture = None
+    instance.capture = None
     return mock_bs, instance
 
 
@@ -263,6 +264,9 @@ class TestEngineObserve:
         assert label == "login"
         assert storage.run_dir.parent.parent == tmp_path
         assert storage.run_dir.parent.name == "hl-session"
+        # Credentials are scrubbed from the HAR, and the run dir is shown to the user.
+        assert sorted(save.await_args.kwargs["redact"]) == ["p", "u"]
+        assert save.await_args.kwargs["console"] is not None
         # Full capture: bodies go to the run dir, not the header-only capture.
         assert ccb.call_args.kwargs["bodies_dir"] == storage.run_dir / "bodies"
 
@@ -293,7 +297,7 @@ class TestEngineObserve:
         mock_bs, instance = _selenium_session_mock()
         session_capture = MagicMock()
         session_capture.get_header_roles = MagicMock(return_value={"x": {}})
-        instance._capture = session_capture
+        instance.capture = session_capture
         login = generate_login_method(_make_plugin("selenium"))
 
         with (
@@ -304,8 +308,82 @@ class TestEngineObserve:
             login({"username": "u", "password": "p"}, observe_mode="full")
 
         assert mock_bs.call_args.kwargs["observe_mode"] == "full"
-        assert instance._session_name == "hl-session"
+        assert instance.session_name == "hl-session"
+        # The observe HAR carries the login POST; the credentials are scrubbed.
+        assert sorted(instance.observe_redact) == ["p", "u"]
         ccb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_save_failure_does_not_mask_login_outcome(self, tmp_path: Path) -> None:
+        tab = _nodriver_tab("<html>Bad login.</html>")
+        mock_bs, _ = _nodriver_session_mock(tab)
+        login = generate_login_method(_make_plugin("nodriver"))
+
+        with (
+            patch("graftpunk.BrowserSession", mock_bs),
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch(
+                "graftpunk.observe.run.save_observe_run",
+                new_callable=AsyncMock,
+                side_effect=OSError("disk full"),
+            ),
+            patch("graftpunk.plugins.login_engine.LOG") as mock_log,
+        ):
+            result = await login({"username": "u", "password": "p"}, observe_mode="full")
+
+        assert result is False
+        assert mock_log.error.call_args.args[0] == "login_observe_save_failed"
+
+    def test_start_login_capture_builds_real_full_backend(self, tmp_path: Path) -> None:
+        """No factory mock: the real backend receives bodies_dir under the run dir."""
+        from graftpunk.observe import capture as capture_mod
+        from graftpunk.observe.capture import NodriverCaptureBackend
+        from graftpunk.plugins.login_engine import _start_login_capture
+
+        plugin = _make_plugin("nodriver")
+        with (
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch.object(capture_mod, "create_capture_backend", _real_create_capture_backend),
+        ):
+            capture, storage = _start_login_capture(
+                plugin, "nodriver", MagicMock(), "full", get_tab=lambda: None
+            )
+
+        assert isinstance(capture, NodriverCaptureBackend)
+        assert storage is not None
+        assert capture._bodies_dir == storage.run_dir / "bodies"
+        assert storage.run_dir.parent == tmp_path / "hl-session"
+
+    def test_start_login_capture_slugifies_session_name(self, tmp_path: Path) -> None:
+        from graftpunk.plugins.login_engine import _start_login_capture
+
+        plugin = _make_plugin("nodriver")
+        type(plugin).session_name = "My Bank"  # type: ignore[assignment]
+        with patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path):
+            _, storage = _start_login_capture(plugin, "nodriver", MagicMock(), "full")
+
+        assert storage is not None
+        assert storage.run_dir.parent == tmp_path / "my-bank"
+
+    def test_start_login_capture_storage_error_falls_back_to_header_capture(
+        self, tmp_path: Path
+    ) -> None:
+        """An observe request must never break the login it is observing."""
+        from graftpunk.plugins.login_engine import _start_login_capture
+
+        plugin = _make_plugin("nodriver")
+        with (
+            patch("graftpunk.observe.OBSERVE_BASE_DIR", tmp_path),
+            patch("graftpunk.observe.storage.ObserveStorage", side_effect=OSError("read-only fs")),
+            patch("graftpunk.plugins.login_engine.gp_console.warn") as warn,
+            patch("graftpunk.plugins.login_engine.LOG") as mock_log,
+        ):
+            capture, storage = _start_login_capture(plugin, "nodriver", MagicMock(), "full")
+
+        assert storage is None
+        assert capture is not None
+        assert mock_log.warning.call_args.args[0] == "login_observe_unavailable"
+        assert "read-only fs" in warn.call_args.args[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_login_workstation_env.py
+++ b/tests/unit/test_login_workstation_env.py
@@ -83,3 +83,29 @@ def test_envvar_override_resolves_from_file(_fresh, monkeypatch):
     body = make_login_body(plugin, login, {"username": "#u", "password": "#p"})
     body(SimpleNamespace())
     assert captured["username"] == "overridden-user"
+
+
+def test_false_result_message_is_cause_neutral(_fresh, monkeypatch):
+    """login() returning False means 'did not complete', not 'bad credentials'.
+
+    The engine already logged what it detected (failure text, missing success
+    element, rate limiting, empty field); the CLI must not name a cause it did
+    not measure (issue #148 item 2).
+    """
+    monkeypatch.setenv("ACME_USERNAME", "u")
+    monkeypatch.setenv("ACME_PASSWORD", "p")
+
+    body = make_login_body(
+        _plugin(), lambda credentials: False, {"username": "#u", "password": "#p"}
+    )
+    with (
+        patch("graftpunk.cli.login_commands.gp_console.error") as mock_error,
+        pytest.raises(SystemExit),
+    ):
+        body(SimpleNamespace())
+
+    message = mock_error.call_args.args[0]
+    assert "acme" in message
+    assert "did not complete" in message
+    assert "credentials" not in message.lower()
+    assert "--observe=full" in message

--- a/tests/unit/test_observe.py
+++ b/tests/unit/test_observe.py
@@ -2155,3 +2155,34 @@ class TestNodriverConsoleCapture:
         response = backend._request_map["r1"]["response"]
         assert response.get("body") is None
         assert response.get("_bodyFile") is None
+
+
+class TestSeleniumStopCaptureIdempotent:
+    def test_second_stop_does_not_redrain_or_refetch(self) -> None:
+        """The login engine stops the session's capture to read header roles, then
+        BrowserSession.__exit__ stops it again; the second call must be a no-op."""
+        from graftpunk.observe.capture import SeleniumCaptureBackend
+
+        driver = MagicMock()
+        driver.get_log = MagicMock(return_value=[])
+        backend = SeleniumCaptureBackend(driver)
+        backend.start_capture()
+
+        backend.stop_capture()
+        backend.stop_capture()
+
+        perf_drains = [c for c in driver.get_log.call_args_list if c.args == ("performance",)]
+        assert len(perf_drains) == 1
+
+    def test_start_capture_resets_the_guard(self) -> None:
+        from graftpunk.observe.capture import SeleniumCaptureBackend
+
+        driver = MagicMock()
+        driver.get_log = MagicMock(return_value=[])
+        backend = SeleniumCaptureBackend(driver)
+        backend.stop_capture()
+        backend.start_capture()
+        backend.stop_capture()
+
+        perf_drains = [c for c in driver.get_log.call_args_list if c.args == ("performance",)]
+        assert len(perf_drains) == 2

--- a/tests/unit/test_observe_run.py
+++ b/tests/unit/test_observe_run.py
@@ -1,0 +1,139 @@
+"""Tests for graftpunk.observe.run: run ids, HAR redaction, guarded run saves."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graftpunk.observe.run import REDACTED, make_run_id, redact_har_entries, save_observe_run
+from graftpunk.observe.storage import _SAFE_NAME_RE, ObserveStorage
+
+
+def _entry(**overrides: object) -> dict:
+    e: dict = {
+        "request": {
+            "url": "https://example.com/login?next=%2F",
+            "headers": [{"name": "Authorization", "value": "Basic dXNlcjpodW50ZXIy"}],
+            "postData": {
+                "mimeType": "application/x-www-form-urlencoded",
+                "text": "u=alice&p=hunter2",
+            },
+        },
+        "response": {"headers": [], "content": {"text": '{"echo":"hunter2"}'}},
+    }
+    e.update(overrides)
+    return e
+
+
+class TestMakeRunId:
+    def test_shape(self) -> None:
+        rid = make_run_id()
+        assert _SAFE_NAME_RE.match(rid)
+        assert rid.count("-") == 2
+
+
+class TestRedactHarEntries:
+    def test_raw_value_in_post_body_and_response(self) -> None:
+        out = redact_har_entries([_entry()], ["hunter2"])
+        assert out[0]["request"]["postData"]["text"] == f"u=alice&p={REDACTED}"
+        assert out[0]["response"]["content"]["text"] == f'{{"echo":"{REDACTED}"}}'
+
+    def test_url_encoded_and_json_escaped_forms(self) -> None:
+        secret = "p@ss w/ëird"  # noqa: S105 — test fixture, not a credential
+        e = _entry()
+        e["request"]["postData"]["text"] = "p=p%40ss+w%2F%C3%ABird&q=p%40ss%20w%2F%C3%ABird"
+        e["response"]["content"]["text"] = json.dumps({"pw": secret})
+        out = redact_har_entries([e], [secret])
+        assert secret not in json.dumps(out)
+        assert "p%40ss" not in json.dumps(out)
+        assert out[0]["request"]["postData"]["text"] == f"p={REDACTED}&q={REDACTED}"
+
+    def test_base64_form(self) -> None:
+        b64 = base64.b64encode(b"hunter2").decode()
+        e = _entry()
+        e["request"]["headers"] = [{"name": "X-Token", "value": b64}]
+        out = redact_har_entries([e], ["hunter2"])
+        assert out[0]["request"]["headers"][0]["value"] == REDACTED
+
+    def test_short_or_empty_secrets_are_skipped(self) -> None:
+        e = _entry()
+        out = redact_har_entries([e], ["", "ab"])
+        assert out == [e]
+
+    def test_does_not_mutate_input(self) -> None:
+        e = _entry()
+        before = json.dumps(e)
+        redact_har_entries([e], ["hunter2"])
+        assert json.dumps(e) == before
+
+    def test_no_secrets_returns_entries_unchanged(self) -> None:
+        e = [_entry()]
+        assert redact_har_entries(e, []) is e
+
+
+def _backend(har: list | None = None) -> MagicMock:
+    b = MagicMock()
+    b.take_screenshot = AsyncMock(return_value=b"\x89PNG")
+    b.get_page_source = AsyncMock(return_value="<html/>")
+    b.stop_capture_async = AsyncMock()
+    b.get_har_entries = MagicMock(return_value=har if har is not None else [_entry()])
+    b.get_console_logs = MagicMock(return_value=[{"level": "log"}])
+    return b
+
+
+class TestSaveObserveRun:
+    @pytest.mark.asyncio
+    async def test_writes_everything_and_redacts_har(self, tmp_path: Path) -> None:
+        storage = ObserveStorage(tmp_path, "sess", "run1")
+        backend = _backend()
+
+        await save_observe_run(storage, backend, "login", redact=["hunter2"])
+
+        backend.stop_capture_async.assert_awaited_once()
+        assert (storage.run_dir / "page-source.html").read_text() == "<html/>"
+        assert list((storage.run_dir / "screenshots").glob("*login*.png"))
+        har = json.loads((storage.run_dir / "network.har").read_text())
+        assert "hunter2" not in json.dumps(har)
+        assert REDACTED in json.dumps(har)
+
+    @pytest.mark.asyncio
+    async def test_one_failed_write_does_not_stop_the_others_or_raise(self, tmp_path: Path) -> None:
+        storage = ObserveStorage(tmp_path, "sess", "run2")
+        backend = _backend()
+        console = MagicMock()
+
+        with (
+            patch.object(storage, "write_har", side_effect=OSError("disk full")),
+            patch("graftpunk.observe.run.LOG") as mock_log,
+        ):
+            await save_observe_run(storage, backend, "go", console=console)
+
+        # HAR failed, logged; console logs and page source still landed.
+        assert any(
+            c.args[0] == "observe_run_write_failed" and c.kwargs["step"] == "HAR"
+            for c in mock_log.error.call_args_list
+        )
+        assert (storage.run_dir / "console.jsonl").exists()
+        assert (storage.run_dir / "page-source.html").exists()
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "HAR failed" in printed
+        assert "Observe run:" in printed
+
+    @pytest.mark.asyncio
+    async def test_stop_capture_failure_still_writes_har(self, tmp_path: Path) -> None:
+        storage = ObserveStorage(tmp_path, "sess", "run3")
+        backend = _backend()
+        backend.stop_capture_async = AsyncMock(side_effect=ConnectionError("browser gone"))
+
+        await save_observe_run(storage, backend, "go")
+
+        assert (storage.run_dir / "network.har").exists()
+
+    @pytest.mark.asyncio
+    async def test_console_none_is_silent(self, tmp_path: Path) -> None:
+        storage = ObserveStorage(tmp_path, "sess", "run4")
+        await save_observe_run(storage, _backend(), "go")  # no console -> no error

--- a/tests/unit/test_plugin_commands.py
+++ b/tests/unit/test_plugin_commands.py
@@ -659,10 +659,11 @@ class TestAutoLoginCommand:
         assert fn.__name__ == "login"
         assert "Log in to testlogin site" in fn.__doc__
 
-        # Only --headless beyond ctx -- credentials are gathered via
-        # prompts/envvars at runtime (include_builtin_options=False).
+        # A hand-written login(credentials) takes no headless kwarg, so no
+        # flags are offered -- credentials are gathered via prompts/envvars
+        # at runtime (include_builtin_options=False).
         params = [p for p in inspect.signature(fn).parameters if p != "ctx"]
-        assert params == ["headless"]
+        assert params == []
 
     def test_login_command_envvar_resolution(self) -> None:
         """Test that environment variables are resolved at runtime."""

--- a/tests/unit/test_plugin_commands.py
+++ b/tests/unit/test_plugin_commands.py
@@ -659,10 +659,10 @@ class TestAutoLoginCommand:
         assert fn.__name__ == "login"
         assert "Log in to testlogin site" in fn.__doc__
 
-        # No params beyond ctx -- credentials are gathered via prompts/envvars
-        # at runtime (include_builtin_options=False, zero param_specs).
+        # Only --headless beyond ctx -- credentials are gathered via
+        # prompts/envvars at runtime (include_builtin_options=False).
         params = [p for p in inspect.signature(fn).parameters if p != "ctx"]
-        assert params == []
+        assert params == ["headless"]
 
     def test_login_command_envvar_resolution(self) -> None:
         """Test that environment variables are resolved at runtime."""

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -5,6 +5,7 @@ for integration tests. These unit tests focus on testable components that
 don't require actual browser instantiation.
 """
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1923,3 +1924,75 @@ class TestNodriverBrowserExecutablePath:
         _, kwargs = gb.call_args
         assert "browser_executable_path" not in kwargs
         reset_settings()
+
+
+class TestObserveStartHardening:
+    """BrowserSession._start_observe: unsafe names are slugified; storage errors
+    degrade to no capture; the HAR is redacted on write."""
+
+    def _make_session(self, observe_mode: str = "full", session_name: str = "My Bank") -> Any:
+        from graftpunk.session import BrowserSession
+
+        with patch.object(BrowserSession, "__init__", return_value=None):
+            session = BrowserSession.__new__(BrowserSession)
+            session._backend_type = "selenium"
+            session._backend_instance = None
+            session._observe_mode = observe_mode
+            session._capture = None
+            session._observe_storage = None
+            session._observe_redact = ()
+            session._session_name = session_name
+            session._webdriver = MagicMock()
+            return session
+
+    def test_unsafe_session_name_is_slugified(self, tmp_path: Path) -> None:
+        session = self._make_session()
+        with (
+            patch("graftpunk.session.OBSERVE_BASE_DIR", tmp_path),
+            patch("graftpunk.session.create_capture_backend") as ccb,
+        ):
+            session._start_observe()
+
+        assert session._observe_storage is not None
+        assert session._observe_storage.run_dir.parent == tmp_path / "my-bank"
+        ccb.return_value.start_capture.assert_called_once()
+
+    def test_storage_error_skips_capture_with_warning(self, tmp_path: Path) -> None:
+        session = self._make_session()
+        with (
+            patch("graftpunk.session.OBSERVE_BASE_DIR", tmp_path),
+            patch("graftpunk.session.ObserveStorage", side_effect=OSError("read-only")),
+            patch("graftpunk.session.gp_console.warn") as warn,
+            patch("graftpunk.session.create_capture_backend") as ccb,
+        ):
+            session._start_observe()
+
+        assert session._capture is None
+        assert session._observe_storage is None
+        ccb.assert_not_called()
+        assert "read-only" in warn.call_args.args[0]
+
+    def test_write_observe_data_redacts_secrets(self, tmp_path: Path) -> None:
+        from graftpunk.observe.run import REDACTED
+        from graftpunk.observe.storage import ObserveStorage
+
+        session = self._make_session(session_name="bank")
+        session.observe_redact = ["hunter2", ""]
+        session._observe_storage = ObserveStorage(tmp_path, "bank", "run1")
+        session._capture = MagicMock()
+        session._capture.get_har_entries = MagicMock(
+            return_value=[{"request": {"postData": {"text": "p=hunter2"}}, "response": {}}]
+        )
+        session._capture.get_console_logs = MagicMock(return_value=[])
+
+        session._write_observe_data()
+
+        har = (tmp_path / "bank" / "run1" / "network.har").read_text()
+        assert "hunter2" not in har
+        assert REDACTED in har
+
+    def test_public_accessors(self) -> None:
+        session = self._make_session()
+        assert session.capture is None
+        session.observe_redact = ["a", None, "b"]
+        assert session.observe_redact == ("a", "b")


### PR DESCRIPTION
## Summary
Closes all four items in #148.

**1. Stale element handle (the actual bug).** `_fill_field` in `login_engine`: each attempt re-selects the element, clears it (and re-clears once if a previous attempt's keystrokes flushed late — doubled text is the worse failure), types, waits `_FIELD_SETTLE_DELAY` (0.4 s — `Input.dispatchKeyEvent` is acked before the renderer updates the value; the issue's measurements show verify-and-retype *without* the settle is worse than no fix), then reads the value back **by selector from the live DOM** (JSON `{found, value}`, never via the handle). Empty read-back or a vanished selector → retry, then `PluginError` naming the field. Non-empty-but-different (sites that lowercase/trim/mask) → warn and proceed. Interaction exceptions on a detached handle count as a failed attempt. Read-back impossible → single fill stands. Logs carry lengths, never values.

**2. Failure message.** `_check_login_result` reports a `Too Many Requests` page as `login_rate_limited` (only when the success element was *not* found — it refines a failure, never vetoes a success, since `page_text` is raw HTML); failure-text / success-element warnings carry hints saying what was measured. The CLI message is cause-neutral and points at the logged warning and `--observe=full`.

**3. `--observe=full` covers `login`.** nodriver: full capture backend + `ObserveStorage` under the (slugified) session name, saved in a `finally` so a *failed* login is captured, run dir printed to stderr. selenium: `observe_mode` passed to `BrowserSession` (owner of the single-consumer performance log), its capture reused for header roles; `SeleniumCaptureBackend.stop_capture` is now idempotent. **Credentials are scrubbed from the HAR** (`graftpunk.observe.run.redact_har_entries`: raw, URL-encoded, JSON-escaped, base64) on both backends. Storage errors degrade to header-only capture with a warning; every write is guarded so a disk error never replaces the login outcome. `save_observe_run` is shared with `observe go` / `interactive`.

**4. Headless override.** `LoginConfig.headless` (Python + YAML, default `False`) and `login --headless` / `--headful` (mutually exclusive; neither → config decides), offered only on declarative logins. Generated `login()` gains keyword-only `headless` / `observe_mode`; the CLI passes only kwargs the callable declares as optional, so hand-written `login(credentials)` is untouched and gets no flag it cannot honour. Generated logins' help reads "Log in to <site>" again.

## Review
Two independent reviews (pr-review-toolkit, superpowers). Every finding at every severity was applied in commits 4–9: one Critical (plaintext credentials in the observed-login HAR → redaction), the rate-limit veto, value-normalising sites hard-failing, exceptions bypassing the fill retry, vanished-selector treated as unverifiable, invisible run dir, double selenium stop, help-text regression, one-way `--headless`, storage errors breaking login, unguarded saves, private-attribute access, duplicated run-id code, stale docstrings, docs overclaiming the selenium run contents, missing CHANGELOG, and the observe tests silently skipping the read-back path (now a stateful fake field).

## Known gap found during verification — filed as #153
The capture keeps only the final hop of a redirect chain (pre-existing, deliberate in both backends), so a login `POST` that answers with a redirect is absent from the HAR; XHR/JSON logins are captured in full. Documented in `HOW_IT_WORKS.md`; fix is a per-hop HAR entry, separate PR.

## Test plan
- [x] `NO_COLOR=1 uv run pytest tests/` → 2332 passed; `ruff check` / `format --check` clean.
- [x] Real CLI: `gp quotes login --help` shows "Log in to quotes" with `--headless` and `--headful`.
- [x] E2E (nodriver 0.48.1, YAML plugin, quotes.toscrape.com): `gp -vv --observe=full quotes login --headless` → logged in headless on attempt 1 with the read-back verification running for real (no `login_field_*` mismatch/unverifiable events), run saved with screenshot + page source + HAR + summary line, listed by `gp observe list`, run dir printed.
- [x] E2E redaction: the saved HAR contains neither credential string. (Caveat: the login POST itself is absent due to #153, so on this site the redaction had nothing to scrub; the unit tests cover raw/URL-encoded/JSON/base64 forms in postData, headers and bodies.)
- [x] `_read_field_value` / `Element.clear_input` semantics checked against real nodriver 0.48.1 and 0.50.3 classes by both reviewers.
- [ ] `[manual, post-merge]` On the original site (private plugin), run `gp --observe=full <plugin> login` once and confirm: login succeeds on attempt 1 or the error names the field; the run dir prints; `grep -c '<password>' <run>/network.har` is 0.

Closes #148