### PR TITLE
fix(nodriver): delete_all_cookies sends the CDP generator (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`NoDriverBackend.delete_all_cookies()` raised `TypeError` on every nodriver version** ([#152](https://github.com/stavxyz/graftpunk/issues/152)). It passed the method name as a string to `tab.send()`, which expects the CDP generator; the `TypeError` escaped the best-effort `except` instead of returning `False`. Now sends `Network.clearBrowserCookies` properly and is covered by a test that executes the coroutine against a nodriver-faithful `send()`.
+
 ## [1.13.0] - 2026-08-24
 
 ### Added

--- a/src/graftpunk/backends/nodriver.py
+++ b/src/graftpunk/backends/nodriver.py
@@ -733,11 +733,13 @@ class NoDriverBackend:
         if self._page is None:
             LOG.debug("nodriver_delete_cookies_no_page")
             return True  # No page = no cookies to delete
-        # nodriver doesn't have delete_all_cookies, so use CDP directly
+        # nodriver doesn't have delete_all_cookies, so use CDP directly.
+        # send() takes the CDP generator, not a method-name string: nodriver
+        # calls next() on it, so a string raised TypeError (issue #152).
+        import nodriver.cdp.network as cdp_network
+
         try:
-            await self._page.send(
-                "Network.clearBrowserCookies",  # type: ignore[arg-type]
-            )
+            await self._page.send(cdp_network.clear_browser_cookies())  # type: ignore[attr-defined]
             return True
         except (RuntimeError, ConnectionError, TimeoutError) as exc:
             # CDP operations can fail; warn user

--- a/tests/unit/test_nodriver_properties.py
+++ b/tests/unit/test_nodriver_properties.py
@@ -1,6 +1,8 @@
 """Tests for NoDriverBackend property accessors and cookie operations."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from graftpunk.backends.nodriver import NoDriverBackend
 
@@ -162,3 +164,47 @@ class TestNoDriverBackendCookies:
         backend = NoDriverBackend()
         result = backend.delete_all_cookies()
         assert result is True
+
+
+class TestDeleteAllCookiesAsync:
+    """_delete_all_cookies_async must hand send() a CDP generator (issue #152).
+
+    Both nodriver lineages call ``next(cdp_obj)`` on the argument; a method-name
+    string raises TypeError, which the best-effort except tuple does not
+    catch, so delete_all_cookies() propagated instead of returning False.
+    The mocked-asyncio.run tests above never execute this coroutine, hence
+    the direct tests here.
+    """
+
+    @staticmethod
+    def _nodriver_like_send(sent: list) -> object:
+        async def send(cdp_obj, *args, **kwargs):  # noqa: ANN001, ANN202
+            method, *params = next(cdp_obj).values()  # what nodriver does
+            sent.append(method)
+            return {}
+
+        return send
+
+    @pytest.mark.asyncio
+    async def test_sends_cdp_generator_for_clear_browser_cookies(self) -> None:
+        backend = NoDriverBackend()
+        backend._page = MagicMock()
+        sent: list = []
+        backend._page.send = self._nodriver_like_send(sent)
+
+        assert await backend._delete_all_cookies_async() is True
+        assert sent == ["Network.clearBrowserCookies"]
+
+    @pytest.mark.asyncio
+    async def test_cdp_failure_returns_false(self) -> None:
+        backend = NoDriverBackend()
+        backend._page = MagicMock()
+        backend._page.send = AsyncMock(side_effect=ConnectionError("browser gone"))
+
+        assert await backend._delete_all_cookies_async() is False
+
+    @pytest.mark.asyncio
+    async def test_no_page_is_a_noop_success(self) -> None:
+        backend = NoDriverBackend()
+        backend._page = None
+        assert await backend._delete_all_cookies_async() is True


### PR DESCRIPTION
## Summary
`NoDriverBackend._delete_all_cookies_async` passed `"Network.clearBrowserCookies"` as a string to `tab.send()`. Both nodriver lineages call `next()` on that argument, so it raised `TypeError` on every version — and `TypeError` is not in the best-effort `except (RuntimeError, ConnectionError, TimeoutError)` at either layer, so `delete_all_cookies()` propagated instead of returning `False`. The `# type: ignore[arg-type]` was suppressing a correct diagnostic.

Now sends `nodriver.cdp.network.clear_browser_cookies()` (verified to exist and yield `Network.clearBrowserCookies` on 0.48.1 and 0.50.3).

## Why the tests missed it
The existing `delete_all_cookies` tests patch `asyncio.run`, so the coroutine body never executed. Added `TestDeleteAllCookiesAsync`, which runs the coroutine directly against a `send()` that does what nodriver does (`next(cdp_obj)`); it fails with the reported `TypeError` before the fix.

## Test plan
- [x] `NO_COLOR=1 uv run pytest tests/` → 2335 passed; ruff clean.
- [x] Real browser (nodriver 0.48.1, headless, single event loop): after loading a cookie-setting page (`cookies.get_all()` → 1), `_delete_all_cookies_async()` returned `True` and `cookies.get_all()` → 0. (The sync `delete_all_cookies()` wrapper was not smoke-tested end to end: calling the sync backend API repeatedly outside `BrowserSession` hangs on the second `asyncio.run` — pre-existing, unrelated to this fix, and worth its own look.)
- [x] CHANGELOG `[Unreleased]` entry.

Closes #152